### PR TITLE
Fixes the spell "lichdom", a known bug.

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -197,10 +197,10 @@
 	category = "Assistance"
 	cost = 1
 
-/datum/spellbook_entry/lichdom
-	name = "Bind Soul"
-	spell_type = /obj/effect/proc_holder/spell/targeted/lichdom
-	category = "Defensive"
+// /datum/spellbook_entry/lichdom
+//	name = "Bind Soul"
+//	spell_type = /obj/effect/proc_holder/spell/targeted/lichdom
+//	category = "Defensive"
 
 /datum/spellbook_entry/teslablast
 	name = "Tesla Blast"


### PR DESCRIPTION
:cl: PopNotes
fix: Lichdom was mistakenly allowed as a spellbook choice for wizards.
/:cl:

[why]: Everyone knows lichdom, it's a very commonly used Wizard ability. What most people _don't_ realize is that the entire existence of lichdom is an unintended glitch, so I'm fixing that now. 