### PR TITLE
Removes the Build Your Own Shuttle Kit from the purchasable shuttles list

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -42,7 +42,7 @@
 
 // Shuttles start here:
 
-/datum/map_template/shuttle/emergency/airless
+///datum/map_template/shuttle/emergency/airless
 	suffix = "airless"
 	name = "Build your own shuttle kit"
 	description = "Save money by building your own shuttle! The chassis will dock upon purchase, but launch will have to be authorized as usual via shuttle call. Interior and atmosphere not included."

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -42,21 +42,21 @@
 
 // Shuttles start here:
 
-///datum/map_template/shuttle/emergency/airless
-//	suffix = "airless"
-//	name = "Build your own shuttle kit"
-//	description = "Save money by building your own shuttle! The chassis will dock upon purchase, but launch will have to be authorized as usual via shuttle call. Interior and atmosphere not included."
-//	admin_notes = "No brig, no medical facilities, no air."
-//	credit_cost = -7500
+/datum/map_template/shuttle/emergency/airless
+	suffix = "airless"
+	name = "Build your own shuttle kit"
+	description = "Save money by building your own shuttle! The chassis will dock upon purchase, but launch will have to be authorized as usual via shuttle call. Interior and atmosphere not included."
+	admin_notes = "No brig, no medical facilities, no air."
+	credit_cost = -7500
 
-///datum/map_template/shuttle/emergency/airless/prerequisites_met()
-//	// first 10 minutes only
-//	return world.time - SSticker.round_start_time < 6000
+/datum/map_template/shuttle/emergency/airless/prerequisites_met()
+	// first 10 minutes only
+	return world.time - SSticker.round_start_time < 6000
 
-///datum/map_template/shuttle/emergency/airless/on_bought()
-//	//enable buying engines from cargo
-//	var/datum/supply_pack/P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shuttle_engine]
-//	P.special_enabled = TRUE
+/datum/map_template/shuttle/emergency/airless/on_bought()
+	//enable buying engines from cargo
+	var/datum/supply_pack/P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shuttle_engine]
+	P.special_enabled = TRUE
 
 /datum/map_template/shuttle/emergency/asteroid
 	suffix = "asteroid"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -43,21 +43,20 @@
 // Shuttles start here:
 
 ///datum/map_template/shuttle/emergency/airless
-	suffix = "airless"
-	name = "Build your own shuttle kit"
-	description = "Save money by building your own shuttle! The chassis will dock upon purchase, but launch will have to be authorized as usual via shuttle call. Interior and atmosphere not included."
-	admin_notes = "No brig, no medical facilities, no air."
-	credit_cost = -7500
+//	suffix = "airless"
+//	name = "Build your own shuttle kit"
+//	description = "Save money by building your own shuttle! The chassis will dock upon purchase, but launch will have to be authorized as usual via shuttle call. Interior and atmosphere not included."
+//	admin_notes = "No brig, no medical facilities, no air."
+//	credit_cost = -7500
 
-/datum/map_template/shuttle/emergency/airless/prerequisites_met()
-	// first 10 minutes only
-	return world.time - SSticker.round_start_time < 6000
+///datum/map_template/shuttle/emergency/airless/prerequisites_met()
+//	// first 10 minutes only
+//	return world.time - SSticker.round_start_time < 6000
 
-/datum/map_template/shuttle/emergency/airless/on_bought()
-	//enable buying engines from cargo
-	var/datum/supply_pack/P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shuttle_engine]
-	P.special_enabled = TRUE
-
+///datum/map_template/shuttle/emergency/airless/on_bought()
+//	//enable buying engines from cargo
+//	var/datum/supply_pack/P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shuttle_engine]
+//	P.special_enabled = TRUE
 
 /datum/map_template/shuttle/emergency/asteroid
 	suffix = "asteroid"

--- a/config/unbuyableshuttles.txt
+++ b/config/unbuyableshuttles.txt
@@ -13,7 +13,7 @@
 
 ##Others
 #_maps/shuttles/emergency_asteroid.dmm
-#_maps/shuttles/emergency_airless.dmm
+maps/shuttles/emergency_airless.dmm
 #_maps/shuttles/emergency_arena.dmm
 #_maps/shuttles/emergency_bar.dmm
 #_maps/shuttles/emergency_clown.dmm


### PR DESCRIPTION
:cl: PopNotes
del: Goodbye, Build Your Own Shuttle, nobody will miss you.
/:cl:

I don't know anyone who doesn't hate this piece of shit. The only reason I have ever seen anyone buy it is to be a le epic trel, forcing people to use pods. The amount of times I've heard "Welp, clown busted into bridge and bought the kit, guess we don't get to have a shuttle party." is stupidly high.

Even the asteroid, the _fucking_ asteroid is a better shuttle, since it arrives with its own atmos.

Delet this.