### PR TITLE
Changelings absorb people faster

### DIFF
--- a/code/game/gamemodes/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/changeling/powers/absorb.dm
@@ -42,7 +42,7 @@
 				target.take_overall_damage(40)
 
 		SSblackbox.add_details("changeling_powers","Absorb DNA|[i]")
-		if(!do_mob(user, target, 150))
+		if(!do_mob(user, target, 100))
 			to_chat(user, "<span class='warning'>Our absorption of [target] has been interrupted!</span>")
 			changeling.isabsorbing = 0
 			return


### PR DESCRIPTION
:cl: PopNotes
tweak: Changelings now absorb people faster.
/:cl:

Changeling is an antag type with a lot of flaws. Among horrible balance issues and the genuinely confusing changes /tg/ made to it long ago that unlocked every single power except for spiderlings at roundstart, it isn't anywhere near the gamemode it was intended to be. It's more of a 'murderbone with your cool powers' game instead of a 'kidnap people and disguise as them to fool the crew' game.

While I definitely plan to try my hand at rebalancing changelings in the future, as of right now I'm aiming to fix an issue I've taken notice of- the fact that absorbing takes centuries. With the way changelings used to be, a long absorb time made **sense**, because it unlocked sweet-ass powers. However, with the way things are now there's really no good reason for absorbing to take as long as it does.