### PR TITLE
Disables Blob

### DIFF
--- a/hippiestation/code/game/gamemodes/disabled_gamemodes.dm
+++ b/hippiestation/code/game/gamemodes/disabled_gamemodes.dm
@@ -1,0 +1,2 @@
+/datum/game_mode/blob
+var/probability = 0


### PR DESCRIPTION
:cl: Mlgdatboiwew
add: A file for disabling gamemodes
tweak: Disables blob
/:cl:

I don't think people wanted all references to blob removed so I instead referenced it in a DM and set the probability to 0.
