### PR TITLE
The Bar Unfuckening

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaa" = (
 /turf/open/space/basic,
 /area/space)
@@ -17325,19 +17325,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aND" = (
-/obj/structure/closet/gmcloset,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/cable_coil,
-/obj/item/device/flashlight/lamp,
-/obj/item/device/flashlight/lamp/green,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "aNE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -62210,6 +62197,20 @@
 /obj/item/book/manual/barman_recipes,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"Unp" = (
+/obj/structure/closet/gmcloset,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/cable_coil,
+/obj/item/device/flashlight/lamp,
+/obj/item/device/flashlight/lamp/green,
+/obj/item/screwdriver,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "UZd" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/wood,
@@ -99338,7 +99339,7 @@ aHM
 aJm
 aKz
 aKR
-aND
+Unp
 aJC
 ftJ
 NnN

--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
 "aaa" = (
 /turf/open/space/basic,
 /area/space)
@@ -17,9 +17,6 @@
 /area/space)
 "aac" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate)
-"aad" = (
-/turf/closed/wall/mineral/titanium,
 /area/shuttle/syndicate)
 "aae" = (
 /obj/effect/landmark/carpspawn,
@@ -2118,9 +2115,6 @@
 "aeE" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/pod_3)
-"aeF" = (
-/turf/closed/wall/mineral/titanium/overspace,
-/area/shuttle/pod_3)
 "aeG" = (
 /obj/structure/cable,
 /obj/machinery/power/solar{
@@ -2848,12 +2842,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"age" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "agf" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal{
@@ -3009,12 +2997,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"agv" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "agw" = (
 /obj/structure/table,
 /obj/machinery/syndicatebomb/training,
@@ -4800,15 +4782,6 @@
 /obj/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/labor)
-"ajY" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Unfiltered to Port";
-	on = 0
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "ajZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -6005,9 +5978,6 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"amx" = (
-/turf/closed/wall,
-/area/maintenance/commiespy)
 "amy" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -7327,20 +7297,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"apv" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fitness Maitenance";
-	req_access_txt = "12"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
 "apw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -7509,15 +7465,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"apT" = (
-/obj/structure/chair/comfy/beige{
-	desc = "It looks comfy and extra tactical.\n<span class='notice'>Alt-click to rotate it clockwise.</span>";
-	dir = 1;
-	icon_state = "comfychair";
-	name = "tactical armchair"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "apU" = (
 /turf/open/floor/plating,
 /area/security/vacantoffice/b)
@@ -7944,18 +7891,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
-"aqU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Cargo Technician"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "aqV" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -8032,10 +7967,6 @@
 "arf" = (
 /turf/closed/wall,
 /area/crew_quarters/dorms)
-"arg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/maintenance/department/crew_quarters/dorms)
 "arh" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Dormitories Maintenance";
@@ -8302,15 +8233,6 @@
 "arP" = (
 /turf/closed/wall,
 /area/maintenance/fore)
-"arQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/eva)
 "arR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 2;
@@ -8523,18 +8445,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"asq" = (
-/obj/machinery/camera{
-	c_tag = "Fitness Room"
-	},
-/obj/structure/closet/masks,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/neutral/side{
-	dir = 1
-	},
-/area/crew_quarters/fitness)
 "asr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -8764,12 +8674,6 @@
 	},
 /turf/open/floor/plating,
 /area/hippie/pool)
-"asZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/yellowsiding/corner{
-	dir = 8
-	},
-/area/hippie/pool)
 "ata" = (
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -8969,10 +8873,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/fore)
-"atz" = (
-/mob/living/simple_animal/mouse,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
 "atA" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -9295,31 +9195,6 @@
 	},
 /turf/open/pool,
 /area/hippie/pool)
-"aut" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/crew_quarters/fitness)
-"auu" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"auv" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/crew_quarters/fitness)
 "auw" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -9420,14 +9295,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"auH" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -9768,34 +9635,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"avw" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/neutral/side{
-	dir = 8
-	},
-/area/crew_quarters/fitness)
 "avx" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/hippie/pool)
-"avy" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
-/area/crew_quarters/fitness)
 "avz" = (
 /obj/machinery/drain,
 /obj/item/bikehorn/rubberducky,
 /turf/open/pool,
 /area/hippie/pool)
-"avA" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/crew_quarters/fitness)
 "avB" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -10250,10 +10099,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"awy" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
 "awz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -10542,10 +10387,6 @@
 	dir = 4
 	},
 /area/construction/mining/aux_base)
-"axd" = (
-/mob/living/simple_animal/mouse,
-/turf/open/floor/plating,
-/area/maintenance/arrivals/north)
 "axe" = (
 /obj/machinery/sleeper{
 	dir = 4;
@@ -10899,39 +10740,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hippie/pool)
-"axS" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 8;
-	on = 1;
-	scrub_Toxins = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/crew_quarters/fitness)
-"axT" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"axU" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/black,
-/area/crew_quarters/fitness)
 "axV" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -10940,15 +10748,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"axW" = (
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	icon_state = "left";
-	name = "Fitness Ring"
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/black,
-/area/crew_quarters/fitness)
 "axX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -10958,11 +10757,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"axY" = (
-/turf/open/floor/plasteel/green/side{
-	dir = 4
-	},
-/area/crew_quarters/fitness)
 "axZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -10980,12 +10774,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hippie/pool)
-"ayb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
 "ayc" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -11446,10 +11234,6 @@
 "aze" = (
 /turf/open/floor/plasteel/neutral/side,
 /area/crew_quarters/dorms)
-"azf" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
 "azg" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -11474,58 +11258,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"azj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/turf/open/floor/plasteel/neutral/side{
-	dir = 10
-	},
-/area/crew_quarters/fitness)
-"azk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"azl" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 8
-	},
-/area/crew_quarters/fitness)
-"azm" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"azn" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"azo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
 "azp" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -11924,72 +11656,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
-	},
-/area/hippie/pool)
-"aAl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
-	},
-/area/hippie/pool)
-"aAm" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
-	},
-/area/hippie/pool)
-"aAn" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/neutral/side,
-/area/crew_quarters/fitness)
-"aAo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/machinery/light,
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 1
 	},
@@ -12793,12 +12459,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"aCf" = (
-/obj/machinery/camera{
-	c_tag = "Theatre Storage"
-	},
-/turf/open/floor/plasteel/purple,
-/area/crew_quarters/theatre)
 "aCg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12808,10 +12468,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"aCh" = (
-/obj/machinery/vending/autodrobe,
-/turf/open/floor/plasteel/purple,
-/area/crew_quarters/theatre)
 "aCi" = (
 /obj/structure/grille,
 /obj/structure/cable,
@@ -12886,17 +12542,6 @@
 	dir = 4
 	},
 /area/hallway/secondary/entry)
-"aCq" = (
-/obj/structure/table/wood,
-/obj/machinery/requests_console{
-	department = "Theatre";
-	departmentType = 0;
-	name = "theatre RC";
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/purple,
-/area/crew_quarters/theatre)
 "aCr" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
@@ -12929,14 +12574,6 @@
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/hippie/pool)
-"aCw" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
 	},
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -13359,11 +12996,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
-"aDu" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "aDv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -13500,14 +13132,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
-"aDJ" = (
-/obj/structure/table,
-/obj/item/device/flashlight/lamp{
-	pixel_x = 4;
-	pixel_y = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "aDK" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm1";
@@ -13752,16 +13376,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
-"aEi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Chapel Maintenance";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aEj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
@@ -14206,16 +13820,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"aFj" = (
-/turf/open/floor/plasteel/purple,
-/area/crew_quarters/theatre)
-"aFk" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/plasteel/purple,
-/area/crew_quarters/theatre)
 "aFl" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -14342,19 +13946,6 @@
 /turf/open/floor/plating,
 /area/chapel/office)
 "aFz" = (
-/turf/open/floor/plasteel/black,
-/area/chapel/main)
-"aFA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/computer/pod/old{
-	density = 0;
-	icon = 'icons/obj/airlock_machines.dmi';
-	icon_state = "airlock_control_standby";
-	id = "chapelgun";
-	name = "Mass Driver Controller";
-	pixel_x = 24;
-	pixel_y = 0
-	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
 "aFB" = (
@@ -14849,13 +14440,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aGD" = (
-/obj/structure/table/wood,
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/purple,
-/area/crew_quarters/theatre)
 "aGE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -14908,21 +14492,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"aGI" = (
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -15194,13 +14763,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
-"aHi" = (
-/obj/structure/closet/coffin,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
 "aHj" = (
 /obj/machinery/light_switch{
 	pixel_x = -20;
@@ -15223,14 +14785,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
-"aHl" = (
-/obj/structure/closet/coffin,
-/obj/machinery/door/window/eastleft{
-	name = "Coffin Storage";
-	req_access_txt = "22"
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/office)
 "aHm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -15277,12 +14831,6 @@
 "aHs" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Arrivals Shuttle Airlock"
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/arrival)
-"aHt" = (
-/obj/effect/landmark{
-	name = "Observer-Start"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
@@ -15411,17 +14959,10 @@
 	dir = 4
 	},
 /area/crew_quarters/dorms)
-"aHI" = (
-/turf/open/floor/plasteel/purple,
-/area/crew_quarters/theatre)
 "aHJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/gateway)
-"aHK" = (
-/obj/structure/closet/secure_closet/freezer/cream_pie,
-/turf/open/floor/plasteel/purple,
-/area/crew_quarters/theatre)
 "aHL" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -15591,13 +15132,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"aId" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aIe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -15642,12 +15176,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/kitchen)
-"aIi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
 /area/crew_quarters/kitchen)
 "aIj" = (
 /obj/structure/cable{
@@ -15834,10 +15362,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/chapel/office)
-"aIE" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/chapel,
-/area/chapel/main)
 "aIF" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -16108,13 +15632,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"aJk" = (
-/obj/machinery/door/airlock{
-	name = "Theatre Backstage";
-	req_access_txt = "46"
-	},
-/turf/open/floor/plasteel/purple,
-/area/crew_quarters/theatre)
 "aJl" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/machinery/light{
@@ -16253,14 +15770,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aJE" = (
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/gun/ballistic/revolver/doublebarrel,
-/obj/structure/table/wood,
-/obj/item/stack/spacecash/c10,
-/obj/item/stack/spacecash/c100,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "aJF" = (
 /obj/machinery/newscaster{
 	pixel_x = 30
@@ -17038,28 +16547,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/chapel/main)
-"aLs" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Arrivals Shuttle Airlock"
-	},
-/obj/docking_port/mobile{
-	dwidth = 5;
-	height = 7;
-	id = "arrival";
-	name = "arrival shuttle";
-	port_direction = 8;
-	preferred_direction = 8;
-	width = 15
-	},
-/obj/docking_port/stationary{
-	dwidth = 5;
-	height = 7;
-	id = "arrival_home";
-	name = "port bay 1";
-	width = 15
-	},
-/turf/open/floor/plating,
-/area/shuttle/arrival)
 "aLt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -17263,18 +16750,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aLU" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "aLV" = (
 /obj/machinery/light{
 	dir = 1
@@ -17565,15 +17040,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/office)
-"aML" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 4;
-	on = 1;
-	scrub_N2O = 0;
-	scrub_Toxins = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main)
 "aMM" = (
 /obj/machinery/camera{
 	c_tag = "Chapel North";
@@ -17801,12 +17267,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"aNu" = (
-/obj/structure/closet/secure_closet/bar{
-	req_access_txt = "25"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "aNv" = (
 /turf/open/floor/plasteel{
 	icon = 'hippiestation/icons/turf/floors.dmi';
@@ -18036,16 +17496,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/office)
-"aNX" = (
-/obj/item/device/radio/intercom{
-	broadcasting = 1;
-	frequency = 1480;
-	name = "Confessional Intercom";
-	pixel_x = 25
-	},
-/obj/structure/chair,
-/turf/open/floor/plasteel/black,
-/area/chapel/main)
 "aNY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -18053,40 +17503,11 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
-"aNZ" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/red/side{
-	dir = 9
-	},
-/area/hallway/secondary/exit)
-"aOa" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/chair,
-/turf/open/floor/plasteel/red/side{
-	dir = 1
-	},
-/area/hallway/secondary/exit)
 "aOb" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/area/hallway/secondary/exit)
-"aOc" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"aOd" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aOe" = (
 /obj/item/device/radio/beacon,
@@ -18606,25 +18027,6 @@
 	dir = 1
 	},
 /area/chapel/main)
-"aPo" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/tinted/fulltile,
-/turf/open/floor/plasteel/black,
-/area/chapel/main)
-"aPp" = (
-/obj/machinery/camera{
-	c_tag = "Escape Arm Holding Area";
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/red/side{
-	dir = 8
-	},
-/area/hallway/secondary/exit)
 "aPq" = (
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -18666,26 +18068,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"aPw" = (
-/obj/machinery/disposal/bin,
-/obj/structure/sign/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
-	pixel_x = -28;
-	pixel_y = -4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "barShutters";
-	name = "bar shutters";
-	pixel_x = 4;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/bar,
-/area/crew_quarters/bar)
 "aPx" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1;
@@ -18786,18 +18168,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aPP" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer,
-/obj/item/device/radio/intercom{
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel/bar,
-/area/crew_quarters/bar)
 "aPQ" = (
 /turf/closed/wall,
 /area/storage/tools)
@@ -18939,9 +18309,6 @@
 /obj/item/device/instrument/violin,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"aQc" = (
-/turf/open/floor/plasteel/bar,
-/area/crew_quarters/bar)
 "aQd" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/assistant,
@@ -18973,13 +18340,6 @@
 	dir = 5
 	},
 /area/hydroponics)
-"aQi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/plasteel/bar,
-/area/crew_quarters/bar)
 "aQj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -19075,24 +18435,6 @@
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
-/area/chapel/main)
-"aQz" = (
-/obj/item/device/radio/intercom{
-	broadcasting = 1;
-	frequency = 1480;
-	name = "Confessional Intercom";
-	pixel_x = 25
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main)
-"aQA" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth"
-	},
-/turf/open/floor/plasteel/black,
 /area/chapel/main)
 "aQB" = (
 /turf/open/floor/plasteel/red/side,
@@ -19290,10 +18632,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"aRg" = (
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/plasteel/bar,
-/area/crew_quarters/bar)
 "aRh" = (
 /obj/machinery/light{
 	dir = 8
@@ -19424,13 +18762,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"aRz" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/open/floor/plasteel/bar,
-/area/crew_quarters/bar)
 "aRA" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/cafeteria,
@@ -19646,14 +18977,6 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"aSb" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "aSc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -19849,10 +19172,6 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel,
 /area/bridge)
-"aSF" = (
-/mob/living/carbon/monkey/punpun,
-/turf/open/floor/plasteel/bar,
-/area/crew_quarters/bar)
 "aSG" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
@@ -19868,13 +19187,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aSI" = (
-/obj/machinery/door/airlock/glass{
-	name = "Kitchen";
-	req_access_txt = "28"
-	},
-/turf/open/floor/plasteel/bar,
-/area/crew_quarters/kitchen)
 "aSJ" = (
 /obj/effect/landmark/start/cook,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19991,34 +19303,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"aSY" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
-/turf/open/floor/plasteel/bar,
-/area/crew_quarters/bar)
-"aSZ" = (
-/obj/effect/landmark/start/bartender,
-/turf/open/floor/plasteel/bar,
-/area/crew_quarters/bar)
-"aTa" = (
-/obj/machinery/requests_console{
-	department = "Bar";
-	departmentType = 2;
-	pixel_x = 30;
-	pixel_y = 0;
-	receive_ore_updates = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Bar";
-	dir = 8;
-	network = list("SS13")
-	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks,
-/turf/open/floor/plasteel/bar,
-/area/crew_quarters/bar)
 "aTb" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -20101,21 +19385,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"aTn" = (
-/obj/machinery/door/airlock/external{
-	cyclelinkeddir = 4;
-	name = "Escape Airlock"
-	},
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit)
 "aTo" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 8;
@@ -20123,9 +19392,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"aTp" = (
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "aTq" = (
 /turf/closed/wall,
 /area/hippie/clown)
@@ -20541,14 +19807,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aUy" = (
-/obj/machinery/camera{
-	c_tag = "Vacant Office";
-	dir = 4;
-	network = list("SS13")
-	},
-/turf/open/floor/wood,
-/area/security/vacantoffice)
 "aUz" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/airalarm{
@@ -20558,11 +19816,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/hydroponics)
-"aUA" = (
-/obj/structure/table/wood,
-/obj/item/device/flashlight/lamp,
-/turf/open/floor/wood,
-/area/security/vacantoffice)
 "aUB" = (
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/wood,
@@ -20630,14 +19883,6 @@
 	dir = 8
 	},
 /area/hallway/secondary/exit)
-"aUM" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals Bay 2";
-	dir = 8;
-	network = list("SS13")
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "aUN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/cafeteria,
@@ -20649,21 +19894,9 @@
 	},
 /turf/open/floor/plasteel/redyellow,
 /area/hippie/clown)
-"aUP" = (
-/obj/machinery/airalarm{
-	frequency = 1439;
-	pixel_y = 23
-	},
-/turf/open/floor/wood,
-/area/security/vacantoffice)
 "aUQ" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/hippie/mime)
-"aUR" = (
-/obj/structure/table/wood,
-/obj/item/pen/red,
-/turf/open/floor/wood,
-/area/security/vacantoffice)
 "aUS" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -20699,11 +19932,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aUW" = (
-/obj/structure/table/wood,
-/obj/item/device/flashlight/lamp/green,
-/turf/open/floor/wood,
-/area/security/vacantoffice)
 "aUX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -21009,17 +20237,7 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aVy" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/bar,
-/area/crew_quarters/bar)
 "aVz" = (
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"aVA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/snacks/pie/cream,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aVB" = (
@@ -21345,17 +20563,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"aWm" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = -28;
-	pixel_y = 0
-	},
-/turf/open/floor/wood,
-/area/security/vacantoffice)
 "aWn" = (
 /obj/structure/closet/wardrobe/black,
 /obj/item/clothing/shoes/jackboots,
@@ -21404,12 +20611,6 @@
 /obj/structure/closet/crate/wooden/toy,
 /turf/open/floor/plasteel/redyellow,
 /area/hippie/clown)
-"aWt" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/vacantoffice)
 "aWu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -21891,28 +21092,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aXj" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/turf/open/floor/plasteel/bar,
-/area/crew_quarters/bar)
-"aXk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
-/obj/item/book/manual/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/plasteel/bar,
-/area/crew_quarters/bar)
-"aXl" = (
-/obj/machinery/door/window/southright{
-	name = "Bar Door";
-	req_access_txt = "0";
-	req_one_access_txt = "25;28"
-	},
-/turf/open/floor/plasteel/bar,
-/area/crew_quarters/bar)
 "aXm" = (
 /obj/effect/landmark/start/cook,
 /turf/open/floor/plasteel/cafeteria,
@@ -22041,12 +21220,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/closed/wall,
 /area/maintenance/port)
-"aXF" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/crew_quarters/fitness)
 "aXG" = (
 /obj/machinery/light{
 	dir = 4;
@@ -22057,15 +21230,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"aXH" = (
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "syndieshutters";
-	name = "remote shutter control";
-	req_access_txt = "150"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "aXI" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 4;
@@ -22127,15 +21291,6 @@
 /obj/item/storage/crayons,
 /turf/open/floor/plasteel/redyellow,
 /area/hippie/clown)
-"aXO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 1;
-	on = 1;
-	scrub_N2O = 0;
-	scrub_Toxins = 0
-	},
-/turf/open/floor/plasteel/bar,
-/area/crew_quarters/bar)
 "aXP" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -23303,17 +22458,6 @@
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"baG" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -24665,10 +23809,6 @@
 /obj/structure/closet/crate/medical,
 /turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/storage)
-"bdV" = (
-/obj/item/stack/sheet/metal,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "bdW" = (
 /obj/item/clothing/gloves/color/rainbow,
 /obj/item/clothing/head/soft/rainbow,
@@ -25570,13 +24710,6 @@
 	dir = 10
 	},
 /area/hallway/secondary/exit)
-"bgf" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "bgg" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/escape{
@@ -26296,18 +25429,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"bhK" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
 "bhL" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 1;
@@ -26341,14 +25462,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bhP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 8;
-	on = 1;
-	scrub_Toxins = 0
-	},
-/turf/open/floor/plasteel/white,
-/area/science/robotics/lab)
 "bhQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -26737,15 +25850,6 @@
 "biL" = (
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"biM" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/landmark/start{
-	name = "Roboticist"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/robotics/lab)
 "biN" = (
 /turf/open/floor/plasteel/whitered/side{
 	dir = 1
@@ -26865,10 +25969,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"biZ" = (
-/obj/machinery/computer/shuttle/syndicate,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "bja" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -27140,18 +26240,6 @@
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"bjD" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Bridge Maintenance APC";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/bridge)
 "bjE" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -27311,15 +26399,6 @@
 	dir = 2
 	},
 /area/medical/medbay/central)
-"bjW" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
 "bjX" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -27394,14 +26473,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
-"bkg" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/open/floor/circuit,
-/area/science/robotics/mechbay)
 "bkh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/circuit,
@@ -27444,23 +26515,6 @@
 	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/science/robotics/lab)
-"bkl" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_research{
-	name = "Robotics Lab";
-	req_access_txt = "29"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bkm" = (
@@ -28262,10 +27316,6 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"blN" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/white,
-/area/science/robotics/lab)
 "blO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -28836,26 +27886,6 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/science/robotics/mechbay)
-"bnd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
-"bne" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bnf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -29476,14 +28506,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"bop" = (
-/obj/machinery/mech_bay_recharge_port,
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/turf/open/floor/plating,
-/area/science/robotics/mechbay)
 "boq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
@@ -29510,14 +28532,6 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
-/area/science/robotics/lab)
-"bot" = (
-/obj/structure/grille,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
 /area/science/robotics/lab)
 "bou" = (
 /turf/open/floor/plasteel,
@@ -30306,21 +29320,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/science/robotics/lab)
-"bqb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
 "bqc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/white,
@@ -30822,17 +29821,6 @@
 	},
 /turf/closed/wall,
 /area/medical/genetics)
-"bri" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 1;
-	on = 1;
-	scrub_N2O = 0;
-	scrub_Toxins = 0
-	},
-/turf/open/floor/plasteel/whiteblue/side{
-	dir = 2
-	},
-/area/medical/medbay/central)
 "brj" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -30849,16 +29837,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"brl" = (
-/obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/robotics/lab)
 "brm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31558,10 +30536,6 @@
 	dir = 9
 	},
 /area/science/research)
-"bsB" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "bsC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
@@ -31637,14 +30611,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard)
-"bsK" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/disks{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "bsL" = (
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -31836,10 +30802,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"btk" = (
-/obj/structure/closet/wardrobe/white,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "btl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	on = 1;
@@ -32296,15 +31258,6 @@
 	dir = 5
 	},
 /area/medical/genetics)
-"bug" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
-"buh" = (
-/turf/closed/wall/r_wall,
-/area/science/robotics/mechbay)
 "bui" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -32499,10 +31452,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"buA" = (
-/obj/structure/frame/computer,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "buB" = (
 /obj/machinery/conveyor_switch/oneway{
 	convdir = -1;
@@ -33484,11 +32433,6 @@
 /obj/structure/sign/nosmoking_2,
 /turf/closed/wall,
 /area/medical/sleeper)
-"bwH" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/turf/open/floor/plasteel,
-/area/medical/sleeper)
 "bwI" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/plasteel,
@@ -33581,14 +32525,6 @@
 	dir = 9
 	},
 /area/science/research)
-"bwP" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "bwQ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -33806,41 +32742,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"bxh" = (
-/obj/machinery/door/poddoor{
-	id = "smindicate";
-	name = "outer blast door"
-	},
-/obj/machinery/button/door{
-	id = "smindicate";
-	name = "external door control";
-	pixel_x = -26;
-	pixel_y = 0;
-	req_access_txt = "150"
-	},
-/obj/docking_port/mobile{
-	dheight = 9;
-	dir = 2;
-	dwidth = 5;
-	height = 24;
-	id = "syndicate";
-	name = "syndicate infiltrator";
-	port_direction = 1;
-	roundstart_move = "syndicate_away";
-	width = 18
-	},
-/obj/docking_port/stationary{
-	dheight = 9;
-	dir = 2;
-	dwidth = 5;
-	height = 24;
-	id = "syndicate_nw";
-	name = "northwest of station";
-	turf_type = /turf/open/space;
-	width = 18
-	},
-/turf/open/floor/plating,
-/area/shuttle/syndicate)
 "bxi" = (
 /obj/machinery/computer/aifixer,
 /obj/machinery/requests_console{
@@ -34144,12 +33045,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
-"bxS" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/medical/sleeper)
 "bxT" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -34187,13 +33082,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"bxX" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "bxY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35973,14 +34861,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"bBM" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass{
-	amount = 10
-	},
-/obj/item/device/multitool,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "bBN" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/cmo)
@@ -36978,16 +35858,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"bDX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/mob/living/simple_animal/mouse,
-/turf/open/floor/plasteel/floorgrime,
-/area/science/storage)
 "bDY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -38677,14 +37547,6 @@
 	dir = 8
 	},
 /area/quartermaster/miningdock)
-"bHB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/mob/living/simple_animal/mouse,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "bHC" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -41027,19 +39889,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"bMf" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/item/stack/cable_coil,
-/obj/item/device/multitool,
-/obj/item/stock_parts/cell/high/plus,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
 "bMg" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -41412,13 +40261,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bNa" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space)
 "bNb" = (
 /obj/item/airlock_painter,
 /obj/structure/lattice,
@@ -41432,16 +40274,6 @@
 "bNd" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
-"bNe" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/hand_labeler,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
 "bNf" = (
 /obj/structure/sign/biohazard,
 /turf/closed/wall,
@@ -41830,14 +40662,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"bNX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	on = 1;
-	scrub_N2O = 0;
-	scrub_Toxins = 0
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/science/misc_lab)
 "bNY" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -42957,14 +41781,6 @@
 /obj/structure/closet/wardrobe/virology_white,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"bQG" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/science/misc_lab)
 "bQH" = (
 /obj/structure/closet/l3closet,
 /obj/effect/turf_decal/stripes/line{
@@ -43067,18 +41883,6 @@
 	},
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
-"bQS" = (
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	dir = 2;
-	name = "Science Requests Console";
-	pixel_x = 0;
-	pixel_y = 30;
-	receive_ore_updates = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
 "bQT" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -43142,13 +41946,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"bRc" = (
-/obj/structure/table/wood,
-/obj/item/soap/nanotrasen,
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/maintenance/port/aft)
 "bRd" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/bar,
@@ -43627,10 +42424,6 @@
 /obj/item/device/assembly/signaler,
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
-"bSf" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/floorgrime,
-/area/science/misc_lab)
 "bSg" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
@@ -43693,10 +42486,6 @@
 "bSn" = (
 /obj/structure/chair/stool,
 /turf/open/floor/carpet/black,
-/area/maintenance/port/aft)
-"bSo" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood,
 /area/maintenance/port/aft)
 "bSp" = (
 /obj/structure/grille/broken,
@@ -44225,12 +43014,6 @@
 "bTo" = (
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
-"bTp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
 "bTq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -44633,14 +43416,6 @@
 	receive_ore_updates = 1
 	},
 /turf/open/floor/plasteel/vault,
-/area/science/misc_lab)
-"bUk" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10;
-	pixel_x = 0;
-	initialize_directions = 10
-	},
-/turf/open/floor/plasteel,
 /area/science/misc_lab)
 "bUl" = (
 /obj/structure/disposalpipe/sortjunction{
@@ -45145,14 +43920,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"bVn" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
-	initialize_directions = 11
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/floorgrime,
-/area/science/misc_lab)
 "bVo" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -45589,12 +44356,6 @@
 	},
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
-"bWq" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/science/misc_lab)
 "bWr" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault,
@@ -45977,33 +44738,6 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/vault,
-/area/science/misc_lab)
-"bXi" = (
-/obj/structure/table,
-/obj/item/folder/white,
-/obj/item/folder/white,
-/obj/item/pen,
-/obj/item/device/taperecorder{
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/science/misc_lab)
-"bXj" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/button/ignition{
-	id = "testigniter";
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/machinery/button/door{
-	id = "testlab";
-	name = "Test Chamber Blast Doors";
-	pixel_x = 4;
-	pixel_y = 2;
-	req_access_txt = "55"
-	},
-/turf/open/floor/plasteel/floorgrime,
 /area/science/misc_lab)
 "bXk" = (
 /obj/machinery/navbeacon{
@@ -47249,12 +45983,6 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"bZY" = (
-/obj/item/device/radio/intercom{
-	pixel_x = -25
-	},
-/turf/open/floor/engine,
-/area/science/misc_lab)
 "bZZ" = (
 /obj/structure/sign/radiation,
 /turf/closed/wall,
@@ -47797,10 +46525,6 @@
 /obj/item/grenade/chem_grenade,
 /obj/item/reagent_containers/spray,
 /turf/open/floor/plasteel/vault,
-/area/science/misc_lab)
-"caY" = (
-/obj/item/device/radio/beacon,
-/turf/open/floor/engine,
 /area/science/misc_lab)
 "caZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -49210,13 +47934,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cdP" = (
-/obj/machinery/door/window{
-	name = "Ready Room";
-	req_access_txt = "150"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "cdQ" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb,
@@ -49226,15 +47943,6 @@
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cdS" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
-/area/science/misc_lab)
 "cdT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -49763,12 +48471,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cff" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 1
-	},
-/area/engine/engineering)
 "cfg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -49922,36 +48624,11 @@
 	dir = 1
 	},
 /area/engine/engineering)
-"cfA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cfB" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/area/engine/engineering)
-"cfC" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cfD" = (
 /obj/structure/disposalpipe/segment,
@@ -50377,12 +49054,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cgx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "cgy" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -50476,20 +49147,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cgI" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cgJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cgK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -50522,27 +49179,11 @@
 	dir = 2
 	},
 /area/crew_quarters/heads/chief)
-"cgN" = (
-/obj/structure/closet/radiation,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cgO" = (
 /turf/open/floor/plasteel/neutral{
 	dir = 2
 	},
 /area/crew_quarters/heads/chief)
-"cgP" = (
-/obj/structure/table,
-/obj/item/device/flashlight{
-	pixel_y = 5
-	},
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -5;
-	pixel_y = 6
-	},
-/obj/item/airlock_painter,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cgQ" = (
 /obj/machinery/camera{
 	c_tag = "Engineering East";
@@ -51083,51 +49724,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"chU" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/mob/living/simple_animal/mouse,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"chV" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/tank/internals/emergency_oxygen/engi{
-	pixel_x = 5;
-	pixel_y = 0
-	},
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/glasses/meson/engine,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"chW" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Center";
-	dir = 2;
-	pixel_x = 23
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "chX" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -51138,12 +49734,6 @@
 /area/engine/engineering)
 "chY" = (
 /obj/machinery/shieldgen,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"chZ" = (
-/obj/machinery/the_singularitygen{
-	anchored = 0
-	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cia" = (
@@ -51238,27 +49828,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
-"cii" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/glasses/meson,
-/obj/item/device/geiger_counter,
-/obj/item/device/geiger_counter,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cij" = (
 /obj/machinery/computer/station_alert,
 /obj/item/device/radio/intercom{
@@ -51297,15 +49866,6 @@
 	dir = 2
 	},
 /area/crew_quarters/heads/chief)
-"cil" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/storage/belt/utility,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cim" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -51334,29 +49894,12 @@
 	dir = 2
 	},
 /area/crew_quarters/heads/chief)
-"cip" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "ciq" = (
 /obj/structure/grille,
 /obj/structure/cable,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
-"cir" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cis" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -51579,17 +50122,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"ciV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ciW" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -51698,12 +50230,6 @@
 	dir = 2
 	},
 /area/crew_quarters/heads/chief)
-"cjh" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cji" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -51762,10 +50288,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cjn" = (
-/obj/item/weldingtool,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "cjo" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plasteel,
@@ -52056,10 +50578,6 @@
 	dir = 2
 	},
 /area/crew_quarters/heads/chief)
-"cjZ" = (
-/obj/structure/sign/securearea,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "cka" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -52806,22 +51324,6 @@
 /obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"clK" = (
-/obj/item/device/radio/intercom{
-	desc = "Talk through this. Evilly";
-	freerange = 1;
-	frequency = 1213;
-	name = "Syndicate Intercom";
-	pixel_y = -32;
-	subspace_transmission = 1;
-	syndie = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
-"clL" = (
-/obj/structure/closet/syndicate/personal,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "clM" = (
 /obj/structure/table,
 /obj/item/crowbar/large,
@@ -52899,13 +51401,6 @@
 "clZ" = (
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"cma" = (
-/obj/machinery/door/window{
-	name = "Cockpit";
-	req_access_txt = "150"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "cmb" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -52987,13 +51482,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"cmm" = (
-/obj/structure/chair{
-	dir = 8;
-	name = "tactical chair"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "cmn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -53173,26 +51661,6 @@
 	dir = 9
 	},
 /area/engine/engineering)
-"cmH" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/crowbar/red,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
-"cmI" = (
-/obj/machinery/vending/engivend,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
-	},
-/area/engine/engineering)
-"cmJ" = (
-/obj/structure/table,
-/obj/item/storage/box/zipties{
-	pixel_x = 1;
-	pixel_y = 2
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "cmK" = (
 /obj/machinery/requests_console{
 	announcementConsole = 0;
@@ -53220,12 +51688,6 @@
 	dir = 1
 	},
 /area/engine/engineering)
-"cmM" = (
-/obj/machinery/sleeper/syndie{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/syndicate)
 "cmN" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_y = 32
@@ -53240,13 +51702,6 @@
 	dir = 1
 	},
 /area/engine/engineering)
-"cmO" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/syndicate)
-"cmP" = (
-/turf/open/floor/mineral/titanium,
-/area/shuttle/syndicate)
 "cmQ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -53270,20 +51725,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cmS" = (
-/obj/structure/table,
-/obj/item/stack/medical/ointment,
-/obj/item/stack/medical/bruise_pack,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/syndicate)
-"cmT" = (
-/obj/machinery/suit_storage_unit/syndicate,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "cmU" = (
 /obj/machinery/light/small,
 /turf/open/floor/engine/n2,
@@ -53402,12 +51843,6 @@
 /obj/item/clipboard,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"cnh" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "cni" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -53535,10 +51970,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cns" = (
-/obj/structure/closet/syndicate/nuclear,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "cnt" = (
 /obj/machinery/camera{
 	c_tag = "Engineering West";
@@ -53555,11 +51986,6 @@
 	dir = 1
 	},
 /area/engine/engineering)
-"cnu" = (
-/obj/structure/table,
-/obj/item/device/aicard,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "cnv" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -53598,10 +52024,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cnz" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/syndicate)
 "cnA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -53681,30 +52103,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cnI" = (
-/obj/structure/table,
-/obj/item/grenade/plastic/c4{
-	pixel_x = 2;
-	pixel_y = -5
-	},
-/obj/item/grenade/plastic/c4{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/grenade/plastic/c4{
-	pixel_x = 2;
-	pixel_y = -3
-	},
-/obj/item/grenade/plastic/c4{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/grenade/plastic/c4{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "cnJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -53837,10 +52235,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"cnT" = (
-/obj/structure/sign/bluecross_2,
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate)
 "cnU" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -53859,10 +52253,6 @@
 	},
 /turf/open/floor/plasteel/loadingarea,
 /area/engine/engineering)
-"cnV" = (
-/obj/structure/bed/roller,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/syndicate)
 "cnW" = (
 /turf/open/space,
 /turf/closed/wall/mineral/plastitanium{
@@ -53941,48 +52331,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"coc" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cod" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/syndicate)
-"coe" = (
-/obj/machinery/door/window{
-	dir = 4;
-	name = "EVA Storage";
-	req_access_txt = "150"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "cof" = (
 /obj/machinery/door/airlock/external{
-	req_access_txt = "150"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
-"cog" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "EVA Storage";
 	req_access_txt = "150"
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -53991,64 +52341,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
-/area/shuttle/syndicate)
-"coi" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/space/syndicate/black/red,
-/obj/item/clothing/head/helmet/space/syndicate/black/red,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
-"coj" = (
-/obj/item/device/radio/intercom{
-	desc = "Talk through this. Evilly";
-	freerange = 1;
-	frequency = 1213;
-	name = "Syndicate Intercom";
-	pixel_x = -32;
-	subspace_transmission = 1;
-	syndie = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
-"cok" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
-"col" = (
-/obj/machinery/door/window{
-	dir = 4;
-	name = "Infirmary";
-	req_access_txt = "150"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/syndicate)
-"com" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "Infirmary";
-	req_access_txt = "150"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/syndicate)
-"con" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/bodypart/r_arm/robot,
-/obj/item/bodypart/l_arm/robot,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/syndicate)
-"coo" = (
-/obj/structure/table,
-/obj/item/stock_parts/cell/high{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/stock_parts/cell/high,
-/turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate)
 "cop" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -54225,44 +52517,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"coD" = (
-/obj/structure/table,
-/obj/item/wrench,
-/obj/item/device/assembly/infra,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
-"coE" = (
-/obj/structure/table,
-/obj/item/screwdriver{
-	pixel_y = 9
-	},
-/obj/item/device/assembly/voice{
-	pixel_y = 3
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
-"coF" = (
-/obj/structure/table,
-/obj/item/weldingtool/largetank{
-	pixel_y = 3
-	},
-/obj/item/device/multitool,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
-"coG" = (
-/obj/structure/table,
-/obj/item/device/assembly/signaler,
-/obj/item/device/assembly/signaler,
-/obj/item/device/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/device/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "coH" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -54274,12 +52528,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"coI" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/syndicate)
 "coJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -54319,66 +52567,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"coM" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"coN" = (
-/obj/machinery/door/window/westright{
-	name = "Tool Storage";
-	req_access_txt = "150"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
-"coO" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/syndicate,
-/obj/item/crowbar/red,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
-"coP" = (
-/obj/machinery/door/window{
-	dir = 1;
-	name = "Surgery";
-	req_access_txt = "150"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/syndicate)
-"coQ" = (
-/obj/structure/table,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/syndicate)
-"coR" = (
-/obj/machinery/door/window{
-	dir = 8;
-	name = "Tool Storage";
-	req_access_txt = "150"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "coS" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser{
@@ -54410,52 +52598,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"coU" = (
-/obj/structure/table,
-/obj/item/surgicaldrill,
-/obj/item/circular_saw,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/syndicate)
-"coV" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/structure/mirror{
-	pixel_x = 30
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/syndicate)
-"coW" = (
-/obj/structure/table,
-/obj/item/device/sbeacondrop/bomb{
-	pixel_y = 5
-	},
-/obj/item/device/sbeacondrop/bomb,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
-"coX" = (
-/obj/structure/table,
-/obj/item/grenade/syndieminibomb{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/item/grenade/syndieminibomb{
-	pixel_x = -1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
-"coY" = (
-/obj/machinery/nuclearbomb/syndicate,
-/obj/machinery/door/window{
-	dir = 1;
-	name = "Secure Storage";
-	req_access_txt = "150"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "coZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -54498,12 +52640,6 @@
 	},
 /turf/open/space,
 /area/space)
-"cpf" = (
-/obj/machinery/telecomms/allinone{
-	intercept = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "cpg" = (
 /obj/item/grenade/barrier{
 	pixel_x = 4
@@ -54616,12 +52752,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cpr" = (
-/obj/structure/table,
-/obj/item/cautery,
-/obj/item/scalpel,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/syndicate)
 "cps" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass{
@@ -54665,21 +52795,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cpw" = (
-/obj/structure/table,
-/obj/item/retractor,
-/obj/item/hemostat,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/syndicate)
-"cpx" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cpy" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -54708,17 +52823,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"cpB" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cpC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/landmark/event_spawn,
@@ -54744,23 +52848,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cpF" = (
-/obj/structure/table/optable,
-/obj/item/surgical_drapes,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/syndicate)
 "cpG" = (
 /obj/structure/table/optable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"cpH" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/syndicate)
 "cpI" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 4;
@@ -54981,19 +53073,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cqe" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cqf" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -55031,34 +53110,6 @@
 "cqj" = (
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plating,
-/area/engine/engineering)
-"cqk" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cql" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cqm" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqn" = (
 /obj/structure/grille,
@@ -55202,18 +53253,10 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cqD" = (
-/obj/structure/sign/radiation,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "cqE" = (
 /obj/structure/particle_accelerator/power_box,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cqF" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "cqG" = (
 /obj/structure/rack,
 /obj/item/storage/box/rubbershot{
@@ -55243,12 +53286,6 @@
 /obj/item/screwdriver,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cqI" = (
-/obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_l"
-	},
-/turf/open/floor/plating,
-/area/shuttle/syndicate)
 "cqJ" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -55343,35 +53380,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cqV" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cqW" = (
-/obj/machinery/power/rad_collector{
-	anchored = 1
-	},
-/obj/item/tank/internals/plasma,
-/obj/structure/cable/yellow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cqX" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cqY" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -55400,31 +53408,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cre" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"crf" = (
-/obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_r"
-	},
-/turf/open/floor/plating,
-/area/shuttle/syndicate)
-"crg" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/open/floor/plating,
-/area/shuttle/syndicate)
 "crh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55438,17 +53421,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"crj" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard)
 "crk" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -55528,19 +53500,6 @@
 /obj/item/wirecutters,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cru" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"crv" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "crw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -55662,12 +53621,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/aft)
-"crH" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space)
 "crI" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -55677,13 +53630,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"crJ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space)
 "crK" = (
 /obj/machinery/power/grounding_rod,
 /obj/machinery/camera/emp_proof{
@@ -55691,15 +53637,6 @@
 	network = list("Singularity")
 	},
 /turf/open/floor/plating/airless,
-/area/engine/engineering)
-"crL" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating,
 /area/engine/engineering)
 "crM" = (
 /obj/structure/cable{
@@ -55733,28 +53670,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"crS" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard)
-"crT" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space)
-"crU" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/turf/open/space,
-/area/space)
 "crV" = (
 /obj/item/wrench,
 /turf/open/floor/plating/airless,
@@ -55781,19 +53696,6 @@
 /obj/structure/transit_tube,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"crZ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"csa" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "csb" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
@@ -55812,9 +53714,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/space,
 /area/maintenance/aft)
-"csd" = (
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
 "cse" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -55829,18 +53728,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"csf" = (
-/obj/machinery/power/emitter{
-	anchored = 1;
-	dir = 8;
-	state = 2
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "csg" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 1;
@@ -55850,12 +53737,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"csh" = (
-/obj/structure/transit_tube{
-	icon_state = "D-SW"
-	},
-/turf/open/space,
-/area/space)
 "csi" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 1
@@ -55889,12 +53770,6 @@
 "cso" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/crossing/horizontal,
-/turf/open/space,
-/area/space)
-"csp" = (
-/obj/structure/transit_tube{
-	icon_state = "E-W-Pass"
-	},
 /turf/open/space,
 /area/space)
 "csq" = (
@@ -55933,11 +53808,6 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/disposal/incinerator)
-"css" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space)
 "cst" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -55956,21 +53826,9 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"csv" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "csw" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/space,
-/area/space)
-"csx" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
 /area/space)
 "csy" = (
@@ -55992,11 +53850,6 @@
 	state = 2
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
-"csB" = (
-/obj/item/wirecutters,
-/obj/structure/lattice,
-/turf/open/space,
 /area/space/nearstation)
 "csC" = (
 /obj/effect/turf_decal/stripes/line{
@@ -56027,18 +53880,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"csG" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "csH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -56051,29 +53892,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"csJ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"csK" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"csL" = (
-/obj/structure/transit_tube{
-	icon_state = "D-NE"
-	},
-/turf/open/space,
-/area/space)
 "csM" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -56089,26 +53907,6 @@
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
-"csP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4";
-	d1 = 1;
-	d2 = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
-	initialize_directions = 11
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "csQ" = (
 /obj/item/wrench,
 /turf/open/floor/plating/airless,
@@ -56119,10 +53917,6 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
-"csS" = (
-/obj/item/weldingtool,
-/turf/open/space,
 /area/space/nearstation)
 "csT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -56211,16 +54005,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/space,
 /area/space)
-"cte" = (
-/obj/item/device/radio/off,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"ctf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "ctg" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -56264,30 +54048,12 @@
 	},
 /turf/closed/wall,
 /area/ai_monitored/turret_protected/aisat_interior)
-"ctl" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "ctm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"ctn" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "cto" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Foyer";
@@ -56409,22 +54175,6 @@
 /obj/machinery/power/tracker,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/aft)
-"ctC" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Singularity West";
-	dir = 1;
-	network = list("Singularity")
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"ctD" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Singularity East";
-	dir = 1;
-	network = list("Singularity")
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "ctE" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/plating,
@@ -56823,19 +54573,6 @@
 	dir = 4
 	},
 /area/ai_monitored/turret_protected/aisat_interior)
-"cut" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/rods{
-	amount = 50
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "cuu" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58361,11 +56098,6 @@
 "cxu" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/transport)
-"cxv" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/transport)
 "cxw" = (
 /obj/structure/grille,
 /obj/structure/window/shuttle,
@@ -58393,10 +56125,6 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plating/airless,
-/area/shuttle/transport)
-"cxz" = (
-/obj/machinery/computer/shuttle/ferry/request,
-/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
 "cxA" = (
 /obj/effect/turf_decal/stripes/line{
@@ -58466,10 +56194,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
-"cxH" = (
-/obj/structure/closet/crate,
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/transport)
 "cxI" = (
 /obj/structure/chair{
 	dir = 1
@@ -59060,14 +56784,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"czi" = (
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"czj" = (
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
 "czk" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 8;
@@ -59100,9 +56816,6 @@
 /obj/structure/light_construct,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
-"czo" = (
-/turf/open/space,
-/area/shuttle/syndicate)
 "czp" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -59110,12 +56823,6 @@
 /obj/structure/shuttle/engine/heater,
 /turf/open/floor/plating/airless,
 /area/shuttle/supply)
-"czq" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 5
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate)
 "czr" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/mineral/titanium,
@@ -59196,9 +56903,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"czE" = (
-/turf/open/floor/engine,
-/area/engine/engineering)
 "czF" = (
 /obj/machinery/power/grounding_rod,
 /obj/machinery/camera/emp_proof{
@@ -59357,18 +57061,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"czV" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "czW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -59502,8 +57194,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -59533,18 +57224,9 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cAo" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
 /area/space/nearstation)
 "cAp" = (
 /obj/structure/cable/yellow{
@@ -59595,26 +57277,11 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"cAu" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/emitter{
-	anchored = 1;
-	dir = 4;
-	icon_state = "emitter";
-	state = 2;
-	
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cAv" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -59628,8 +57295,7 @@
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -59637,8 +57303,7 @@
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -59771,23 +57436,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
-"cAO" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cAP" = (
-/obj/structure/sign/fire,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "cAQ" = (
 /obj/structure/chair,
 /turf/open/floor/plating,
@@ -60054,13 +57702,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"cBs" = (
-/obj/structure/table/optable{
-	name = "Robotics Operating Table"
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/white,
-/area/science/robotics/lab)
 "cBt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -60266,15 +57907,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"cBQ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cBR" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/space/basic,
@@ -60365,10 +57997,6 @@
 /obj/item/clothing/under/burial,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"cCa" = (
-/obj/item/clothing/head/hardhat,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "cCb" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -60493,10 +58121,6 @@
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"cCr" = (
-/obj/machinery/deepfryer,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "cCs" = (
 /obj/structure/mining_shuttle_beacon{
 	dir = 4
@@ -60516,9 +58140,6 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/pod/dark,
 /area/shuttle/transport)
-"cCv" = (
-/turf/open/floor/pod/light,
-/area/space)
 "cCw" = (
 /obj/machinery/door/airlock/titanium,
 /turf/open/floor/pod/light,
@@ -60542,133 +58163,6 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/pod/light,
 /area/shuttle/transport)
-"cCA" = (
-/turf/open/floor/pod/light,
-/area/space)
-"cCB" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10;
-	pixel_x = 0;
-	initialize_directions = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"cCC" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"cCD" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Engine";
-	on = 0
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"cCE" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"cCF" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
-"cCG" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/turf/open/space,
-/area/space/nearstation)
-"cCH" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cCI" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cCJ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cCK" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cCL" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cCM" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cCN" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cCO" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cCP" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
-/turf/open/space,
-/area/space/nearstation)
-"cCQ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
-"cCR" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/turf/open/space,
-/area/space/nearstation)
-"cCS" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "cCT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -60678,25 +58172,10 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cCU" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
-"cCV" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
 "cCW" = (
 /obj/machinery/portable_atmospherics/canister/freon,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cCX" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
 "cCY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -60707,123 +58186,10 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cCZ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cDa" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cDb" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cDc" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cDd" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
 "cDe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
-"cDf" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cDg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDh" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/device/flashlight,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/item/pipe_dispenser,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDi" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDj" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
 /area/engine/engineering)
 "cDl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -60839,33 +58205,6 @@
 /obj/machinery/vending/engivend,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cDn" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cDo" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cDp" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cDq" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -60879,61 +58218,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
-"cDr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 4;
-	on = 1;
-	scrub_N2O = 0;
-	scrub_Toxins = 0
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDs" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDu" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cDv" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/trinary/filter/flipped{
-	icon_state = "filter_off_f";
-	dir = 4
-	},
-/turf/open/floor/engine,
 /area/engine/engineering)
 "cDw" = (
 /obj/effect/turf_decal/stripes/line,
@@ -60951,95 +58235,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cDx" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Atmos to Loop";
-	on = 0
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDz" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cDA" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
 "cDB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
-"cDC" = (
-/obj/item/wrench,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cDD" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	name = "scrubbers pipe";
-	icon_state = "manifold";
-	dir = 4
-	},
-/obj/machinery/meter,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cDE" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "External Gas to Loop"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cDF" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "External Gas to Loop"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cDG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
 /area/engine/engineering)
 "cDH" = (
 /obj/machinery/door/airlock/external{
@@ -61055,117 +58256,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cDI" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cDJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cDK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cDL" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cDM" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cDN" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/engine/engineering)
-"cDO" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/engine/engineering)
-"cDP" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/engine/engineering)
-"cDQ" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/engine/engineering)
-"cDR" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cDS" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space)
-"cDT" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space)
-"cDU" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space)
-"cDV" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space)
-"cDW" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
-"cDX" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
-"cDY" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
-/turf/open/space,
-/area/space/nearstation)
 "cDZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -61175,111 +58265,11 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cEa" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cEb" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cEc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Port";
-	dir = 4;
-	network = list("SS13","Engine")
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEf" = (
-/obj/machinery/ai_status_display,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"cEg" = (
-/obj/machinery/status_display,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"cEh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Starboard";
-	dir = 8;
-	network = list("SS13","Engine");
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cEj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cEk" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "cEl" = (
 /turf/open/space,
@@ -61306,13 +58296,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cEo" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space)
 "cEp" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -61322,148 +58305,13 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cEq" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space)
 "cEr" = (
 /turf/open/space/basic,
-/area/space/nearstation)
-"cEs" = (
-/turf/open/floor/plating,
 /area/space/nearstation)
 "cEt" = (
 /obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"cEu" = (
-/obj/machinery/power/rad_collector{
-	anchored = 1
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Supermatter Chamber";
-	dir = 2;
-	network = list("Engine");
-	pixel_x = 23
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cEv" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"cEw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 8;
-	on = 1;
-	scrub_Toxins = 0
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cEx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cEy" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	icon_state = "manifold";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"cEz" = (
-/obj/machinery/power/rad_collector{
-	anchored = 1
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cEA" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"cEB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEC" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Gas";
-	on = 0
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cED" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEE" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/turf/open/space,
-/area/space)
 "cEF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -61473,401 +58321,10 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cEG" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space)
-"cEH" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space)
-"cEI" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space)
-"cEJ" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space)
-"cEK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cEL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEM" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/item/tank/internals/plasma,
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"cEN" = (
-/obj/machinery/power/rad_collector{
-	anchored = 1
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEO" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cEP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 8;
-	on = 1;
-	scrub_Toxins = 0
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cER" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	icon_state = "manifold";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cES" = (
-/obj/machinery/power/rad_collector{
-	anchored = 1
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cET" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"cEU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEV" = (
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cEW" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	icon_state = "connector_map";
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cEX" = (
-/turf/closed/wall/r_wall,
-/area/space)
-"cEY" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cEZ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cFa" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "cFb" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"cFc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4";
-	d1 = 1;
-	d2 = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	icon_state = "pump_map";
-	name = "Cooling Loop Bypass"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFd" = (
-/obj/machinery/power/rad_collector{
-	anchored = 1
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFe" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"cFf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 8;
-	on = 1;
-	scrub_Toxins = 0
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFh" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"cFi" = (
-/obj/machinery/power/rad_collector{
-	anchored = 1
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFj" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"cFk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix Bypass"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFl" = (
-/turf/closed/wall/r_wall,
-/area/space)
-"cFm" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cFn" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/turf/open/space,
-/area/space)
-"cFo" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cFp" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/turf/open/space,
-/area/space)
-"cFq" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cFr" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/turf/open/space,
-/area/space)
-"cFs" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cFt" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/turf/open/space,
-/area/space)
-"cFu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFv" = (
-/obj/machinery/status_display,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cFw" = (
-/obj/structure/sign/electricshock,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"cFx" = (
-/obj/machinery/ai_status_display,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cFy" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFz" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cFA" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cFB" = (
-/turf/closed/wall/r_wall,
-/area/space)
 "cFC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -61889,592 +58346,15 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cFE" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space)
-"cFF" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space)
-"cFG" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space)
-"cFH" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space)
-"cFI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFJ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFL" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 4;
-	filter_type = "co2";
-	on = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cFM" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"cFN" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 4;
-	filter_type = "o2";
-	on = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Aft";
-	dir = 2;
-	network = list("SS13","Engine");
-	pixel_x = 23
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cFP" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 4;
-	filter_type = "plasma";
-	on = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFR" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 4;
-	filter_type = "";
-	on = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFS" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFT" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8;
-	on = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cFV" = (
-/turf/closed/wall/r_wall,
-/area/space)
-"cFW" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cFX" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space)
-"cFY" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cFZ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space)
-"cGa" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cGb" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space)
-"cGc" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cGd" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGe" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cGf" = (
 /obj/item/crowbar,
 /turf/open/space/basic,
 /area/space/nearstation)
-"cGg" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGh" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGi" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGj" = (
-/obj/structure/table,
-/obj/item/pipe_dispenser,
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cGk" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cGl" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cGm" = (
-/turf/closed/wall/r_wall,
-/area/space)
-"cGn" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cGo" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cGp" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cGq" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cGr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cGs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cGt" = (
-/obj/structure/closet/wardrobe/engineering_yellow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGu" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGv" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGw" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGx" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGy" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGz" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGA" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGB" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGC" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/meter,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGD" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGE" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGF" = (
-/turf/closed/wall/r_wall,
-/area/space)
-"cGG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cGH" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Laser Room";
-	req_access_txt = "10"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGJ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Laser Room";
-	req_access_txt = "10"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGK" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGL" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGM" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cGN" = (
-/turf/closed/wall/r_wall,
-/area/space)
-"cGO" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cGP" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cGQ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cGR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 1;
-	on = 1;
-	scrub_N2O = 0;
-	scrub_Toxins = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cGS" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGT" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cGU" = (
-/obj/structure/reflector/double{
-	anchored = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cGV" = (
-/obj/structure/reflector/box{
-	anchored = 1;
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cGW" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cGX" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1;
-	on = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cGZ" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cHa" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cHb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHc" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHd" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHe" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHf" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cHg" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cHh" = (
 /obj/machinery/power/tesla_coil,
 /obj/structure/cable/yellow{
@@ -62483,126 +58363,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"cHi" = (
-/obj/structure/reflector/box{
-	anchored = 1;
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cHj" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/power/emitter{
-	anchored = 1;
-	dir = 8;
-	icon_state = "emitter";
-	state = 2
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cHm" = (
-/turf/closed/wall/r_wall,
-/area/space)
-"cHn" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/light,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHo" = (
-/obj/structure/reflector/single{
-	anchored = 1;
-	dir = 1;
-	icon_state = "reflector"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHp" = (
-/obj/structure/reflector/single{
-	anchored = 1;
-	dir = 4;
-	icon_state = "reflector"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHq" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHr" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/light,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHs" = (
-/obj/item/crowbar/large,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHt" = (
-/turf/closed/wall/r_wall,
-/area/space)
-"cHu" = (
-/turf/closed/wall/r_wall,
-/area/space)
-"cHv" = (
-/turf/closed/wall/r_wall,
-/area/space)
-"cHw" = (
-/turf/closed/wall/r_wall,
-/area/space)
-"cHx" = (
-/turf/closed/wall/r_wall,
-/area/space)
-"cHy" = (
-/turf/closed/wall/r_wall,
-/area/space)
-"cHz" = (
-/turf/closed/wall/r_wall,
-/area/space)
-"cHA" = (
-/turf/closed/wall/r_wall,
-/area/space)
-"cHB" = (
-/turf/closed/wall/r_wall,
-/area/space)
-"cHC" = (
-/obj/structure/chair/stool{
-	desc = "Apply butt, tactically.";
-	name = "tactical stool";
-	pixel_y = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate)
 "cHD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -62880,15 +58640,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"cHY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/science/robotics/lab)
 "cHZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -62953,27 +58704,6 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
 "cIh" = (
-/obj/machinery/door/airlock/external{
-	cyclelinkeddir = 1;
-	name = "Port Docking Bay 1"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
-"cIi" = (
-/obj/machinery/door/airlock/external{
-	cyclelinkeddir = 1;
-	name = "Port Docking Bay 1"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
-"cIj" = (
-/obj/machinery/door/airlock/external{
-	cyclelinkeddir = 1;
-	name = "Port Docking Bay 1"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
-"cIk" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 1;
 	name = "Port Docking Bay 1"
@@ -63070,9 +58800,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/syndicate)
-"cIw" = (
-/turf/open/floor/plasteel/black,
-/area/shuttle/syndicate)
 "cIx" = (
 /obj/structure/chair/office/dark{
 	dir = 4;
@@ -63094,24 +58821,6 @@
 	},
 /area/shuttle/syndicate)
 "cIz" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
-"cIA" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
-"cIB" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
-"cIC" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
-"cID" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
-"cIE" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
-"cIF" = (
 /turf/open/floor/plasteel/vault,
 /area/shuttle/syndicate)
 "cIG" = (
@@ -63161,9 +58870,6 @@
 	dir = 5
 	},
 /area/shuttle/syndicate)
-"cIM" = (
-/turf/open/floor/plasteel/black,
-/area/shuttle/syndicate)
 "cIN" = (
 /obj/structure/chair{
 	dir = 8;
@@ -63186,9 +58892,6 @@
 	dir = 5
 	},
 /area/shuttle/syndicate)
-"cIP" = (
-/turf/open/floor/plasteel/black,
-/area/shuttle/syndicate)
 "cIQ" = (
 /obj/structure/chair{
 	dir = 8;
@@ -63207,41 +58910,10 @@
 	dir = 5
 	},
 /area/shuttle/syndicate)
-"cIS" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cIT" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
 "cIU" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/vault{
 	dir = 8
-	},
-/area/shuttle/syndicate)
-"cIV" = (
-/obj/structure/chair{
-	dir = 4;
-	name = "tactical chair"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cIW" = (
-/turf/open/floor/plasteel/black,
-/area/shuttle/syndicate)
-"cIX" = (
-/obj/structure/chair{
-	dir = 8;
-	name = "tactical chair"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
 	},
 /area/shuttle/syndicate)
 "cIY" = (
@@ -63252,43 +58924,10 @@
 	dir = 4
 	},
 /area/shuttle/syndicate)
-"cIZ" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cJa" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
 "cJb" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel/vault{
 	dir = 8
-	},
-/area/shuttle/syndicate)
-"cJc" = (
-/obj/structure/chair{
-	dir = 4;
-	name = "tactical chair"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cJd" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cJe" = (
-/obj/structure/chair{
-	dir = 8;
-	name = "tactical chair"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
 	},
 /area/shuttle/syndicate)
 "cJf" = (
@@ -63329,24 +58968,6 @@
 	tag = "icon-podhatch (NORTH)";
 	icon_state = "podhatch";
 	dir = 1
-	},
-/area/shuttle/syndicate)
-"cJg" = (
-/obj/machinery/suit_storage_unit/syndicate,
-/turf/open/floor/plasteel/podhatch{
-	tag = "icon-podhatch (EAST)";
-	icon_state = "podhatch";
-	dir = 4
-	},
-/area/shuttle/syndicate)
-"cJh" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cJi" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
 	},
 /area/shuttle/syndicate)
 "cJj" = (
@@ -63392,24 +59013,6 @@
 	dir = 6
 	},
 /area/shuttle/syndicate)
-"cJo" = (
-/obj/machinery/suit_storage_unit/syndicate,
-/turf/open/floor/plasteel/podhatch{
-	tag = "icon-podhatch (EAST)";
-	icon_state = "podhatch";
-	dir = 4
-	},
-/area/shuttle/syndicate)
-"cJp" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cJq" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
 "cJr" = (
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -63424,36 +59027,6 @@
 	dir = 8
 	},
 /area/shuttle/syndicate)
-"cJt" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cJu" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cJv" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cJw" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cJx" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cJy" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
 "cJz" = (
 /obj/machinery/suit_storage_unit/syndicate,
 /turf/open/floor/plasteel/podhatch{
@@ -63462,45 +59035,13 @@
 	dir = 6
 	},
 /area/shuttle/syndicate)
-"cJA" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cJB" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
 "cJC" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/shuttle/syndicate)
-"cJD" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cJE" = (
-/turf/open/floor/plasteel/black,
-/area/shuttle/syndicate)
-"cJF" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
 "cJG" = (
-/obj/structure/chair{
-	dir = 1;
-	name = "tactical chair"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate)
-"cJH" = (
 /obj/structure/chair{
 	dir = 1;
 	name = "tactical chair"
@@ -63521,32 +59062,10 @@
 /obj/machinery/ai_status_display,
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate)
-"cJK" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cJL" = (
-/turf/open/floor/plasteel/black,
-/area/shuttle/syndicate)
-"cJM" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cJN" = (
-/obj/machinery/status_display,
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate)
 "cJO" = (
 /obj/machinery/sleeper/syndie{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate)
-"cJP" = (
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -63603,19 +59122,6 @@
 /obj/item/stack/medical/ointment,
 /turf/open/floor/plasteel/vault{
 	dir = 8
-	},
-/area/shuttle/syndicate)
-"cJT" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cJU" = (
-/turf/open/floor/plasteel/black,
-/area/shuttle/syndicate)
-"cJV" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
 	},
 /area/shuttle/syndicate)
 "cJW" = (
@@ -63685,18 +59191,6 @@
 	dir = 8
 	},
 /area/shuttle/syndicate)
-"cKc" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
-"cKd" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
-"cKe" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
-"cKf" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
 "cKg" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -63706,41 +59200,10 @@
 	dir = 5
 	},
 /area/shuttle/syndicate)
-"cKh" = (
-/turf/open/floor/plasteel/black,
-/area/shuttle/syndicate)
 "cKi" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cKj" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
-"cKk" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
-"cKl" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
-"cKm" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
-"cKn" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
-"cKo" = (
-/obj/machinery/sleeper/syndie{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate)
-"cKp" = (
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -63757,13 +59220,6 @@
 	dir = 1
 	},
 /area/shuttle/syndicate)
-"cKs" = (
-/turf/open/floor/plasteel/podhatch{
-	tag = "icon-podhatch (NORTH)";
-	icon_state = "podhatch";
-	dir = 1
-	},
-/area/shuttle/syndicate)
 "cKt" = (
 /obj/machinery/door/airlock/hatch{
 	req_access_txt = "150"
@@ -63772,56 +59228,8 @@
 	dir = 8
 	},
 /area/shuttle/syndicate)
-"cKu" = (
-/turf/open/floor/plasteel/podhatch{
-	tag = "icon-podhatch (NORTH)";
-	icon_state = "podhatch";
-	dir = 1
-	},
-/area/shuttle/syndicate)
-"cKv" = (
-/turf/open/floor/plasteel/podhatch{
-	tag = "icon-podhatch (NORTH)";
-	icon_state = "podhatch";
-	dir = 1
-	},
-/area/shuttle/syndicate)
-"cKw" = (
-/turf/open/floor/plasteel/podhatch{
-	tag = "icon-podhatch (NORTH)";
-	icon_state = "podhatch";
-	dir = 1
-	},
-/area/shuttle/syndicate)
-"cKx" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate)
-"cKy" = (
-/turf/open/floor/plasteel/podhatch{
-	tag = "icon-podhatch (NORTH)";
-	icon_state = "podhatch";
-	dir = 1
-	},
-/area/shuttle/syndicate)
-"cKz" = (
-/turf/open/floor/plasteel/podhatch{
-	tag = "icon-podhatch (NORTH)";
-	icon_state = "podhatch";
-	dir = 1
-	},
-/area/shuttle/syndicate)
 "cKA" = (
 /turf/open/floor/plasteel/podhatch{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cKB" = (
-/turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/shuttle/syndicate)
@@ -63840,47 +59248,16 @@
 	dir = 8
 	},
 /area/shuttle/syndicate)
-"cKE" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
 "cKF" = (
 /turf/open/floor/plasteel/podhatch{
 	dir = 10
 	},
-/area/shuttle/syndicate)
-"cKG" = (
-/turf/open/floor/plasteel/podhatch,
-/area/shuttle/syndicate)
-"cKH" = (
-/turf/open/floor/plasteel/podhatch,
-/area/shuttle/syndicate)
-"cKI" = (
-/turf/open/floor/plasteel/podhatch,
-/area/shuttle/syndicate)
-"cKJ" = (
-/turf/open/floor/plasteel/podhatch,
-/area/shuttle/syndicate)
-"cKK" = (
-/turf/open/floor/plasteel/podhatch,
-/area/shuttle/syndicate)
-"cKL" = (
-/turf/open/floor/plasteel/podhatch,
-/area/shuttle/syndicate)
-"cKM" = (
-/turf/open/floor/plasteel/podhatch,
 /area/shuttle/syndicate)
 "cKN" = (
 /turf/open/floor/plasteel/podhatch{
 	tag = "icon-podhatch (SOUTHEAST)";
 	icon_state = "podhatch";
 	dir = 6
-	},
-/area/shuttle/syndicate)
-"cKO" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
 	},
 /area/shuttle/syndicate)
 "cKP" = (
@@ -63941,15 +59318,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/vault,
 /area/shuttle/syndicate)
-"cKV" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
-"cKW" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
-"cKX" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
 "cKY" = (
 /obj/item/device/sbeacondrop/bomb{
 	pixel_y = 5
@@ -63981,12 +59349,6 @@
 	dir = 8
 	},
 /area/shuttle/syndicate)
-"cLa" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate)
 "cLb" = (
 /obj/machinery/door/window{
 	dir = 1;
@@ -64015,11 +59377,6 @@
 	dir = 8
 	},
 /area/shuttle/syndicate)
-"cLe" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
 "cLf" = (
 /obj/structure/sink{
 	dir = 4;
@@ -64042,24 +59399,6 @@
 	req_access_txt = "0"
 	},
 /turf/open/floor/circuit/red,
-/area/shuttle/syndicate)
-"cLh" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cLi" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate)
-"cLj" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
 /area/shuttle/syndicate)
 "cLk" = (
 /obj/item/cautery,
@@ -64092,22 +59431,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/shuttle/syndicate)
-"cLo" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate)
-"cLp" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate)
 "cLq" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/circuit/red,
@@ -64117,34 +59440,6 @@
 	intercept = 1
 	},
 /turf/open/floor/circuit/red,
-/area/shuttle/syndicate)
-"cLs" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/circuit/red,
-/area/shuttle/syndicate)
-"cLt" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate)
-"cLu" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate)
-"cLv" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
 /area/shuttle/syndicate)
 "cLw" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -64159,68 +59454,6 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/syndicate)
 "cLy" = (
-/obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_r"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate)
-"cLz" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate)
-"cLA" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate)
-"cLB" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate)
-"cLC" = (
-/obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_l"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate)
-"cLD" = (
-/obj/structure/shuttle/engine/propulsion,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate)
-"cLE" = (
-/obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_r"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate)
-"cLF" = (
-/obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_l"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate)
-"cLG" = (
-/obj/structure/shuttle/engine/propulsion,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate)
-"cLH" = (
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion_r"
 	},
@@ -64369,23 +59602,9 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
-"cMg" = (
-/obj/structure/light_construct,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
 "cMh" = (
 /obj/structure/light_construct/small{
 	dir = 8
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"cMi" = (
-/obj/structure/light_construct,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"cMj" = (
-/obj/structure/light_construct{
-	dir = 1
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
@@ -64402,88 +59621,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/labor)
-"cMm" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
-	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cMn" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cMo" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cMp" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cMq" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cMr" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cMs" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cMt" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cMu" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cMv" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cMw" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cMx" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cMy" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cMz" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cMA" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cMB" = (
 /obj/structure/window/shuttle,
 /obj/structure/grille,
@@ -64510,15 +59647,6 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cME" = (
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"cMF" = (
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"cMG" = (
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "cMH" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -64528,146 +59656,7 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cMI" = (
-/obj/machinery/power/rad_collector{
-	anchored = 1
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cMJ" = (
-/obj/machinery/power/rad_collector{
-	anchored = 1
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cMK" = (
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cML" = (
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"cMM" = (
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"cMN" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"cMO" = (
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"cMP" = (
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "cMQ" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cMR" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cMS" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cMT" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cMU" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cMV" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cMW" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cMX" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cMY" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cMZ" = (
 /obj/structure/cable{
 	icon_state = "0-2";
 	d2 = 2
@@ -64686,281 +59675,13 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/aft)
-"cNb" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNc" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNd" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNe" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNf" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNg" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNh" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNi" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNj" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNk" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNl" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNm" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNn" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNo" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNp" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNq" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNr" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNs" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNt" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNu" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNv" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNw" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNx" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNy" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNz" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNA" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNB" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cNC" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
-"cND" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
 "cNE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"cNF" = (
-/turf/closed/wall,
-/area/quartermaster/sorting)
 "cNG" = (
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"cNH" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "cNI" = (
@@ -64969,12 +59690,6 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "cNJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"cNK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -65017,28 +59732,6 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"cNO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"cNP" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/quartermaster/sorting)
-"cNQ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
 /area/quartermaster/sorting)
 "cNR" = (
 /obj/structure/cable{
@@ -65133,102 +59826,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cOa" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "cOb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cOc" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOd" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
 "cOe" = (
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOf" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOh" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOi" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOj" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOk" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOl" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOm" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOn" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOo" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOp" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOq" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOs" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOt" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOu" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOv" = (
-/turf/closed/wall,
 /area/maintenance/starboard/aft)
 "cOw" = (
 /obj/structure/grille,
@@ -65240,94 +59843,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cOy" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOz" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOA" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOB" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOC" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOD" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOE" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOF" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOG" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOH" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOI" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOJ" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOK" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOL" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOM" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cON" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOO" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOP" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOQ" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOR" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOS" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "cOT" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOU" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOW" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOX" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cOY" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -65337,110 +59853,10 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cPb" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPc" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPd" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPe" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cPf" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPh" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPi" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPj" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cPk" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPm" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPn" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cPo" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cPp" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cPq" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cPr" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPs" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cPt" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cPu" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPv" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPw" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPy" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPz" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "cPA" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cPB" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPC" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPD" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cPE" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cPF" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cPG" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cPH" = (
@@ -65457,158 +59873,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cPJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPK" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPL" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPM" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPN" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPO" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cPP" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPQ" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cPR" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPS" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPT" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPU" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPV" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPW" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPX" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPY" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cPZ" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQa" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQb" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQc" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQd" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQe" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQf" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cQg" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQi" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQj" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQk" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cQl" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cQm" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQn" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQo" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cQp" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cQq" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQr" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQs" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cQt" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cQu" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cQv" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
 "cQw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQx" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQy" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cQz" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
 "cQB" = (
@@ -65626,457 +59894,7 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cQC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cQD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cQE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cQF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cQG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cQH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cQI" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQJ" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQK" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQL" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cQM" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cQN" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQO" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQQ" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQR" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQS" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQT" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQU" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQV" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQW" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQX" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cQY" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cQZ" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRa" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRc" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRd" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRe" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRf" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRh" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRi" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRj" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRk" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRl" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRm" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRo" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRp" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRq" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRr" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRs" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRt" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRu" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRv" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRw" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRx" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRy" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRz" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRA" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRB" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRC" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRG" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRH" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRI" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRJ" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRK" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRL" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRM" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRN" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRO" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRP" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRQ" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRR" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRS" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRT" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRU" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRV" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRW" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cRX" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRY" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cRZ" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cSa" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cSb" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cSc" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cSd" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cSe" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cSf" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cSg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cSh" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cSi" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cSj" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cSk" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cSl" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cSm" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cSn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cSo" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cSp" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cSq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cSr" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cSs" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cSt" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cSu" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cSv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cSw" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cSx" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cSy" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
-"cSz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/chapel/main)
 "cSA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/security/courtroom)
-"cSB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/security/courtroom)
-"cSC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/security/courtroom)
-"cSD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -66121,42 +59939,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/security/brig)
-"cSI" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/security/brig)
-"cSJ" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/security/brig)
 "cSK" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
@@ -66171,14 +59953,6 @@
 	},
 /area/hallway/primary/fore)
 "cSM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/red/corner{
-	dir = 1
-	},
-/area/hallway/primary/fore)
-"cSN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66213,45 +59987,7 @@
 	dir = 1
 	},
 /area/hallway/primary/fore)
-"cSR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/red/corner{
-	dir = 1
-	},
-/area/hallway/primary/fore)
-"cSS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/red/corner{
-	dir = 1
-	},
-/area/hallway/primary/fore)
-"cST" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/red/corner{
-	dir = 1
-	},
-/area/hallway/primary/fore)
-"cSU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/red/corner{
-	dir = 1
-	},
-/area/hallway/primary/fore)
 "cSV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"cSW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66278,10 +60014,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"cTa" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "cTb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -66292,14 +60024,6 @@
 	},
 /area/hallway/primary/fore)
 "cTc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/red/corner{
-	dir = 8
-	},
-/area/hallway/primary/fore)
-"cTd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66342,15 +60066,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hippie/pool)
-"cTi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 8;
-	on = 1;
-	scrub_N2O = 0;
-	scrub_Toxins = 0
-	},
-/turf/open/floor/plasteel/yellowsiding,
-/area/hippie/pool)
 "cTj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -66381,15 +60096,7 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plasteel/cafeteria,
 /area/hippie/mime)
-"cTm" = (
-/turf/closed/wall,
-/area/hippie/clown)
 "cTn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plasteel/redyellow,
-/area/hippie/clown)
-"cTo" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plasteel/redyellow,
@@ -66503,9 +60210,6 @@
 "cTE" = (
 /turf/closed/wall,
 /area/hippie/mime)
-"cTF" = (
-/turf/closed/wall,
-/area/hippie/mime)
 "cTG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -66565,24 +60269,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cTL" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cTM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cTN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -66622,15 +60309,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cTR" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cTS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -66642,36 +60320,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cTT" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cTU" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cTV" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cTW" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/rad_collector{
-	anchored = 1
-	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cTX" = (
@@ -66708,26 +60358,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
-"cUb" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
-"cUc" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cUd" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "cUe" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -66735,14 +60365,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cUf" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
 /area/space/nearstation)
 "cUg" = (
 /obj/machinery/power/emitter{
@@ -66757,22 +60379,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cUh" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/space/nearstation)
-"cUi" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/space/nearstation)
 "cUj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66790,50 +60396,17 @@
 /obj/item/weldingtool,
 /turf/open/space/basic,
 /area/space/nearstation)
-"cUl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/space/nearstation)
 "cUm" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cUn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
 /area/space/nearstation)
 "cUo" = (
 /obj/item/device/radio,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cUp" = (
-/obj/machinery/power/emitter{
-	anchored = 1;
-	dir = 8;
-	icon_state = "emitter";
-	state = 2
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cUq" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cUr" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUs" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
 /area/engine/engineering)
 "cUt" = (
 /obj/machinery/camera/emp_proof{
@@ -66843,64 +60416,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cUu" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cUv" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cUw" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/space/nearstation)
-"cUx" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/space/nearstation)
-"cUy" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "cUz" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Singularity South-East";
@@ -66909,130 +60424,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cUA" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUB" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
-"cUC" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUD" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUE" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "cUF" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
-"cUG" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
-"cUH" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUI" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUJ" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUK" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUL" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUM" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUN" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUO" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUP" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUQ" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUR" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUS" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUT" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUU" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUV" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cUW" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
-"cUX" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
-"cUY" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
-"cUZ" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
-"cVa" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
-"cVb" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
-"cVc" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "cVd" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVe" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVf" = (
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cVg" = (
@@ -67041,106 +60438,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cVh" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVi" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVj" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVk" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVl" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVm" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVn" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVo" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVp" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVq" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVr" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVs" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVt" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVu" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVv" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVw" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVy" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVz" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVA" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVB" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVC" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVD" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVE" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVF" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cVG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Pool";
-	c_tag_order = 999;
-	dir = 1
-	},
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
-	},
-/area/hippie/pool)
 "cVH" = (
 /mob/living/simple_animal/pet/penguin/baby{
 	name = "Newspaper"
@@ -67157,21 +60454,6 @@
 "cVJ" = (
 /turf/open/floor/plasteel/bar,
 /area/maintenance/port/aft)
-"cVK" = (
-/turf/open/floor/plasteel/bar,
-/area/maintenance/port/aft)
-"cVL" = (
-/turf/open/floor/plasteel/bar,
-/area/maintenance/port/aft)
-"cVM" = (
-/turf/open/floor/plasteel/bar,
-/area/maintenance/port/aft)
-"cVN" = (
-/turf/open/floor/plasteel/bar,
-/area/maintenance/port/aft)
-"cVO" = (
-/turf/open/floor/plasteel/bar,
-/area/maintenance/port/aft)
 "cVP" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -67180,14 +60462,6 @@
 "cVQ" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
-/turf/open/floor/plasteel/bar,
-/area/maintenance/port/aft)
-"cVR" = (
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/bar,
-/area/maintenance/port/aft)
-"cVS" = (
-/obj/structure/table/wood,
 /turf/open/floor/plasteel/bar,
 /area/maintenance/port/aft)
 "cVT" = (
@@ -67199,16 +60473,6 @@
 /turf/open/floor/carpet/black,
 /area/maintenance/port/aft)
 "cVV" = (
-/turf/open/floor/carpet/black,
-/area/maintenance/port/aft)
-"cVW" = (
-/turf/open/floor/carpet/black,
-/area/maintenance/port/aft)
-"cVX" = (
-/obj/structure/chair/stool,
-/turf/open/floor/carpet/black,
-/area/maintenance/port/aft)
-"cVY" = (
 /turf/open/floor/carpet/black,
 /area/maintenance/port/aft)
 "cVZ" = (
@@ -67281,12 +60545,6 @@
 /obj/machinery/icecream_vat,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cWn" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cWo" = (
 /obj/structure/statue/sandstone/assistant{
 	anchored = 1;
@@ -67309,11 +60567,6 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"cWs" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "cWt" = (
 /obj/machinery/clonepod,
 /turf/open/floor/plasteel/white,
@@ -67354,91 +60607,10 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"cWz" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cWA" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cWB" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cWC" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cWD" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cWE" = (
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space)
-"cWF" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
-"cWG" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
-"cWH" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
-"cWI" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
-"cWJ" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
-"cWK" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
-"cWL" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
-"cWM" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
-"cWN" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
-"cWO" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
-"cWP" = (
-/turf/closed/wall,
-/area/maintenance/commiespy)
-"cWQ" = (
-/turf/closed/wall,
-/area/maintenance/commiespy)
-"cWR" = (
-/turf/closed/wall,
-/area/maintenance/commiespy)
-"cWS" = (
-/turf/closed/wall,
-/area/maintenance/commiespy)
-"cWT" = (
-/turf/closed/wall,
-/area/maintenance/commiespy)
-"cWU" = (
-/turf/closed/wall,
-/area/maintenance/commiespy)
-"cWV" = (
-/turf/closed/wall,
-/area/maintenance/commiespy)
 "cWW" = (
 /obj/structure/table,
 /obj/item/device/flashlight/lamp,
@@ -67516,26 +60688,16 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/maintenance/commiespy)
-"cXa" = (
-/turf/closed/wall,
-/area/maintenance/commiespy)
 "cXb" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space,
 /area/space)
-"cXc" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
 "cXd" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating/airless,
 /area/maintenance/starboard/fore)
-"cXe" = (
-/turf/closed/wall,
-/area/maintenance/commiespy)
 "cXf" = (
 /obj/structure/table,
 /obj/item/storage/photo_album{
@@ -67575,9 +60737,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/maintenance/commiespy)
-"cXj" = (
-/turf/closed/wall,
-/area/maintenance/commiespy)
 "cXk" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 2;
@@ -67585,9 +60744,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"cXl" = (
-/turf/closed/wall,
-/area/maintenance/commiespy)
 "cXm" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -67618,9 +60774,6 @@
 /obj/item/clothing/neck/stethoscope,
 /turf/open/floor/plasteel/black,
 /area/maintenance/commiespy)
-"cXo" = (
-/turf/open/floor/plasteel/black,
-/area/maintenance/commiespy)
 "cXp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -67630,20 +60783,11 @@
 /obj/machinery/modular_computer/console/preset/command,
 /turf/open/floor/plasteel/black,
 /area/maintenance/commiespy)
-"cXq" = (
-/turf/closed/wall,
-/area/maintenance/commiespy)
 "cXr" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "cXs" = (
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/starboard/fore)
-"cXt" = (
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/starboard/fore)
-"cXu" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/starboard/fore)
 "cXv" = (
@@ -67652,9 +60796,6 @@
 /area/maintenance/starboard/fore)
 "cXw" = (
 /obj/structure/barricade/wooden,
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/starboard/fore)
-"cXx" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/starboard/fore)
 "cXy" = (
@@ -67675,9 +60816,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/wood,
 /area/maintenance/starboard/fore)
-"cXC" = (
-/turf/closed/wall,
-/area/maintenance/commiespy)
 "cXD" = (
 /obj/machinery/vending/sustenance,
 /obj/item/device/radio/intercom{
@@ -67690,12 +60828,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/maintenance/commiespy)
-"cXE" = (
-/turf/open/floor/plasteel/black,
-/area/maintenance/commiespy)
-"cXF" = (
-/turf/open/floor/plasteel/black,
-/area/maintenance/commiespy)
 "cXG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -67705,21 +60837,8 @@
 /obj/machinery/computer/crew,
 /turf/open/floor/plasteel/black,
 /area/maintenance/commiespy)
-"cXH" = (
-/turf/closed/wall,
-/area/maintenance/commiespy)
-"cXI" = (
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/starboard/fore)
 "cXJ" = (
 /obj/item/gun/ballistic/automatic/toy/pistol,
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/starboard/fore)
-"cXK" = (
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/starboard/fore)
-"cXL" = (
-/obj/item/projectile/bullet/reusable/foam_dart,
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/starboard/fore)
 "cXM" = (
@@ -67728,12 +60847,6 @@
 	dir = 8
 	},
 /obj/item/gun/ballistic/shotgun/toy/crossbow,
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/starboard/fore)
-"cXN" = (
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/starboard/fore)
-"cXO" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/starboard/fore)
 "cXP" = (
@@ -67747,12 +60860,6 @@
 "cXR" = (
 /turf/open/floor/wood,
 /area/maintenance/starboard/fore)
-"cXS" = (
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
-"cXT" = (
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "cXU" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 1;
@@ -67760,9 +60867,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"cXV" = (
-/turf/closed/wall,
-/area/maintenance/commiespy)
 "cXW" = (
 /obj/machinery/vending/sovietsoda,
 /turf/open/floor/plasteel/black,
@@ -67795,16 +60899,6 @@
 /obj/item/ammo_casing/caseless/foam_dart,
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/starboard/fore)
-"cYb" = (
-/obj/item/projectile/bullet/reusable/foam_dart,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"cYc" = (
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/starboard/fore)
-"cYd" = (
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/starboard/fore)
 "cYe" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -67813,30 +60907,10 @@
 /obj/item/ammo_box/foambox,
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/starboard/fore)
-"cYf" = (
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/starboard/fore)
-"cYg" = (
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/starboard/fore)
 "cYh" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
-/area/maintenance/starboard/fore)
-"cYi" = (
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
-"cYj" = (
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
-"cYk" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken"
-	},
-/area/maintenance/starboard/fore)
-"cYl" = (
-/turf/open/floor/wood,
 /area/maintenance/starboard/fore)
 "cYm" = (
 /obj/machinery/door/airlock/maintenance{
@@ -67853,25 +60927,12 @@
 /obj/item/ammo_box/foambox,
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/starboard/fore)
-"cYo" = (
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/starboard/fore)
-"cYp" = (
-/obj/item/projectile/bullet/reusable/foam_dart,
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/starboard/fore)
 "cYq" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/starboard/fore)
-"cYr" = (
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/starboard/fore)
-"cYs" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/starboard/fore)
 "cYt" = (
@@ -67892,15 +60953,6 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/starboard/fore)
-"cYv" = (
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
-"cYw" = (
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
-"cYx" = (
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "cYy" = (
 /obj/structure/closet/wardrobe/yellow,
 /turf/open/floor/wood,
@@ -67914,33 +60966,6 @@
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
 "cYA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"cYB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"cYC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"cYD" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -67974,23 +60999,6 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/starboard/fore)
-"cYH" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
-"cYI" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/maintenance/starboard/fore)
-"cYJ" = (
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
-"cYK" = (
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "cYL" = (
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/wood,
@@ -68003,45 +61011,17 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
-"cYN" = (
-/obj/structure/falsewall,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"cYO" = (
-/obj/structure/falsewall,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "cYP" = (
 /obj/machinery/light/small,
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/starboard/fore)
-"cYQ" = (
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
-"cYR" = (
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
-"cYS" = (
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
-"cYT" = (
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "cYU" = (
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
-/area/maintenance/starboard/fore)
-"cYV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/closed/wall,
 /area/maintenance/starboard/fore)
 "cYW" = (
 /obj/item/ammo_box/foambox,
@@ -68071,42 +61051,11 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
-"cZa" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/closed/wall,
-/area/maintenance/starboard/fore)
-"cZb" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/closed/wall,
-/area/maintenance/starboard/fore)
 "cZc" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/turf/closed/wall,
-/area/maintenance/starboard/fore)
-"cZd" = (
-/obj/structure/table,
-/obj/item/gun/ballistic/automatic/toy/pistol,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"cZe" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
@@ -68124,14 +61073,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/hippie/pool)
-"cZg" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/closed/wall,
-/area/maintenance/starboard/fore)
 "cZh" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet/crate,
@@ -68162,14 +61103,6 @@
 /obj/structure/closet/athletic_mixed,
 /turf/open/floor/plasteel,
 /area/hippie/pool)
-"cZl" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/closed/wall,
-/area/maintenance/starboard/fore)
 "cZm" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -68212,21 +61145,6 @@
 "cZr" = (
 /turf/open/floor/plasteel,
 /area/hippie/pool)
-"cZs" = (
-/turf/open/floor/plasteel,
-/area/hippie/pool)
-"cZt" = (
-/turf/open/floor/plasteel,
-/area/hippie/pool)
-"cZu" = (
-/turf/open/floor/plasteel,
-/area/hippie/pool)
-"cZv" = (
-/turf/open/floor/plasteel,
-/area/hippie/pool)
-"cZw" = (
-/turf/open/floor/plasteel,
-/area/hippie/pool)
 "cZx" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -68243,12 +61161,6 @@
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 4
 	},
-/area/hippie/pool)
-"cZy" = (
-/turf/open/floor/plasteel,
-/area/hippie/pool)
-"cZz" = (
-/turf/open/floor/plasteel,
 /area/hippie/pool)
 "cZA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -68304,9 +61216,6 @@
 "cZI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light,
-/turf/open/floor/plasteel/neutral/side,
-/area/hippie/pool)
-"cZJ" = (
 /turf/open/floor/plasteel/neutral/side,
 /area/hippie/pool)
 "cZK" = (
@@ -68479,18 +61388,7 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
-"dae" = (
-/obj/structure/closet/coffin,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/black,
-/area/chapel/main)
 "daf" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/chapel{
-	dir = 1
-	},
-/area/chapel/main)
-"dag" = (
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -68571,27 +61469,12 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
-"dat" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/chapel/main)
 "dau" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
 	on = 1;
 	scrub_Toxins = 0
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main)
-"dav" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -68610,12 +61493,6 @@
 	},
 /obj/machinery/light{
 	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/chapel/main)
-"day" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
@@ -68685,10 +61562,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
-"daL" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/black,
-/area/chapel/main)
 "daM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
@@ -68749,10 +61622,6 @@
 	},
 /area/hallway/secondary/exit)
 "daS" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"daT" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -68873,25 +61742,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"dbn" = (
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
-"dbo" = (
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
-"dbp" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
-"dbq" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "dbr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -68913,28 +61763,6 @@
 /mob/living/simple_animal/cow,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
-"dbu" = (
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
-"dbv" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
-"dbw" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"dbx" = (
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
-"dby" = (
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
 "dbz" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -68942,12 +61770,6 @@
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
-"dbA" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "dbB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -68968,12 +61790,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
-"dbE" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "dbF" = (
 /obj/machinery/camera{
 	c_tag = "Escape Hallway South";
@@ -68988,10 +61804,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"dbH" = (
-/obj/item/ammo_casing/caseless/foam_dart,
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/starboard/fore)
 "dbI" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -69019,27 +61831,11 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"dbN" = (
-/turf/open/floor/plasteel/vault,
-/area/science/misc_lab)
 "dbO" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/closet/l3closet/scientist,
-/turf/open/floor/plasteel/vault,
-/area/science/misc_lab)
-"dbP" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/engine,
-/area/science/misc_lab)
-"dbQ" = (
-/turf/open/floor/plasteel/vault,
-/area/science/misc_lab)
-"dbR" = (
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
 "dbS" = (
@@ -69072,22 +61868,7 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
-"dbX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plasteel/vault,
-/area/science/misc_lab)
 "dbY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plasteel/vault,
-/area/science/misc_lab)
-"dbZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -69117,12 +61898,6 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
-	},
-/turf/open/floor/plasteel/vault,
-/area/science/misc_lab)
-"dce" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
@@ -69159,23 +61934,12 @@
 /obj/item/stack/sheet/mineral/plasma,
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
-"dcj" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/vault,
-/area/science/misc_lab)
 "dck" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/science{
 	name = "Lab Storage"
 	},
 /turf/open/floor/plasteel/vault,
-/area/science/misc_lab)
-"dcl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
 /area/science/misc_lab)
 "dcm" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -69283,6 +62047,173 @@
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"dxG" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/structure/reagent_dispensers/chemical,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"elp" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that{
+	throwforce = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"eLM" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"fiD" = (
+/obj/effect/landmark/start/bartender,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"fnE" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/rag,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"ftJ" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/chem_dispenser/drinks/beer,
+/obj/item/device/radio/intercom{
+	pixel_y = 25
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"jrh" = (
+/obj/structure/disposalpipe/segment,
+/mob/living/carbon/monkey/punpun,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"kxC" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"lfB" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"pms" = (
+/obj/machinery/door/window/eastleft{
+	dir = 8;
+	icon_state = "right";
+	name = "Kitchen Window";
+	req_access_txt = "0"
+	},
+/obj/item/reagent_containers/food/snacks/pie/cream,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"sKc" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/spacecash/c100,
+/obj/item/stack/spacecash/c100,
+/obj/item/stack/spacecash/c100,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"uMd" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Bar";
+	departmentType = 2;
+	pixel_x = 30;
+	pixel_y = 0;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"AoF" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/machinery/camera{
+	c_tag = "Bar";
+	dir = 2;
+	network = list("SS13")
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Bii" = (
+/obj/machinery/door/window/southright{
+	name = "Bar Door";
+	req_access_txt = "0";
+	req_one_access_txt = "25;28"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"HzI" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"MTE" = (
+/obj/structure/disposalpipe/segment{
+	base_icon_state = null;
+	dir = 1;
+	dpdir = 0;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"NnN" = (
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/table/reinforced,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Prn" = (
+/obj/structure/table/wood,
+/obj/item/gun/ballistic/revolver/doublebarrel{
+	desc = "The barkeeper's trusty double-barrel. Works beautifully, despite its age.";
+	name = "Ol' Faithful"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"RCR" = (
+/obj/structure/sign/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
+	pixel_x = -28;
+	pixel_y = -4
+	},
+/obj/machinery/button/door{
+	id = "barShutters";
+	name = "bar shutters";
+	pixel_x = 4;
+	pixel_y = 28
+	},
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Tar" = (
+/obj/structure/closet/secure_closet/bar,
+/obj/item/book/manual/barman_recipes,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"UZd" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aaa
@@ -83539,13 +76470,13 @@ aNf
 aLA
 aQD
 aSd
-cTm
-cTm
-cTm
-cTm
+aTq
+aTq
+aTq
+aTq
 cTu
 baJ
-cTm
+aTq
 cTI
 beO
 beU
@@ -83802,7 +76733,7 @@ cWp
 aWs
 cTv
 cTA
-cTm
+aTq
 bbf
 beT
 beT
@@ -84316,7 +77247,7 @@ cTr
 aXN
 aUO
 cTB
-cTm
+aTq
 bcI
 aPz
 bdt
@@ -84567,13 +77498,13 @@ ayl
 ayl
 ayl
 aSf
-cTm
-cTm
-cTm
-cTm
-cTm
-cTm
-cTm
+aTq
+aTq
+aTq
+aTq
+aTq
+aTq
+aTq
 aPz
 aPz
 bdB
@@ -88203,8 +81134,8 @@ aaa
 aaa
 bCq
 cVJ
-cVR
-cVX
+bRd
+bSn
 bCq
 aoV
 cbj
@@ -88460,8 +81391,8 @@ aaa
 aaa
 bLv
 cVJ
-cVR
-cVX
+bRd
+bSn
 bCq
 bCq
 cbj
@@ -88717,8 +81648,8 @@ akD
 aaa
 bCq
 cVJ
-cVR
-cVX
+bRd
+bSn
 cVV
 bCq
 cbk
@@ -88974,8 +81905,8 @@ akD
 aaa
 bLv
 bPR
-cVR
-cVX
+bRd
+bSn
 cVZ
 bCq
 bVy
@@ -89232,7 +82163,7 @@ aaa
 bCq
 cVJ
 bRf
-cVX
+bSn
 bTu
 bCq
 bVB
@@ -89489,7 +82420,7 @@ aaa
 bLv
 cVJ
 bRe
-cVX
+bSn
 bTt
 bCq
 bVA
@@ -91515,7 +84446,7 @@ apd
 bbU
 cCk
 apd
-cNF
+aZK
 bgB
 bhX
 bgv
@@ -91775,7 +84706,7 @@ apd
 bfj
 bgC
 bia
-cNF
+aZK
 bjs
 bkx
 bmQ
@@ -92030,9 +84961,9 @@ bbQ
 bLG
 apd
 aZH
-cNF
+aZK
 bhZ
-cNF
+aZK
 cNM
 bfQ
 bnG
@@ -92872,7 +85803,7 @@ abY
 abY
 aaa
 aaf
-cEX
+ctv
 abY
 abY
 aaa
@@ -93062,7 +85993,7 @@ bqp
 cNG
 cNJ
 bLF
-cNF
+aZK
 bbR
 bbR
 bqt
@@ -93119,18 +86050,18 @@ aaa
 crn
 aaf
 abY
-cEX
-cEX
-cEX
-cEX
-cEX
-cEX
-cEX
+ctv
+ctv
+ctv
+ctv
+ctv
+ctv
+ctv
 abY
 aaa
 aaf
-cEX
-cEX
+ctv
+ctv
 abY
 aaa
 aaa
@@ -93319,7 +86250,7 @@ beW
 bfR
 bKF
 bNH
-cNF
+aZK
 bnJ
 bbR
 bbR
@@ -93571,12 +86502,12 @@ baV
 bON
 apd
 apd
-cNF
+aZK
 beV
 cNI
 bKP
 cNI
-cNF
+aZK
 bnK
 bnK
 bqu
@@ -96197,7 +89128,7 @@ cfG
 cgw
 coK
 cpu
-cMm
+cqa
 ccw
 ccw
 ccw
@@ -96455,7 +89386,7 @@ cjN
 chF
 ciO
 cqc
-cTT
+cqC
 cTV
 ccw
 cEr
@@ -96712,11 +89643,11 @@ cjN
 cjS
 cpv
 cqb
-cTU
-cTW
-cWz
+cqB
+cqU
+cMD
 aaH
-cUc
+cAk
 cUe
 cAp
 cUe
@@ -96727,7 +89658,7 @@ cUe
 cAp
 cUe
 cUe
-cUu
+cAv
 cFb
 ccw
 cUq
@@ -96969,9 +89900,9 @@ cgK
 cjS
 cpv
 cqb
-cTU
+cqB
 cTX
-cWz
+cMD
 aaH
 cAl
 aaH
@@ -97226,9 +90157,9 @@ cgU
 chG
 cpv
 cqd
-cTU
-cTW
-cWz
+cqB
+cqU
+cMD
 cEt
 cAl
 csA
@@ -97484,9 +90415,9 @@ ccw
 cpy
 ccw
 ccw
-cWz
-cWz
-cWz
+cMD
+cMD
+cMD
 cAl
 cEr
 cEr
@@ -97498,7 +90429,7 @@ cEr
 cEr
 cEr
 cHh
-cUv
+cAw
 cFb
 ccw
 cUq
@@ -97743,7 +90674,7 @@ cqf
 chX
 chX
 crs
-cWz
+cMD
 cAl
 cEr
 cEr
@@ -97999,8 +90930,8 @@ cTP
 cqh
 ciZ
 cra
-cTR
-cWz
+crI
+cMD
 cAl
 cEr
 cEr
@@ -98269,7 +91200,7 @@ cFb
 cEr
 cEr
 cHh
-cUv
+cAw
 cEr
 ccw
 cUq
@@ -98506,7 +91437,7 @@ cfb
 cfb
 cig
 cmN
-cTL
+cnx
 cgL
 chX
 cTQ
@@ -98514,7 +91445,7 @@ cqj
 cqH
 crb
 ciZ
-cWz
+cMD
 cAl
 csA
 cFb
@@ -98766,12 +91697,12 @@ cfz
 cgR
 ccw
 ciZ
-cTR
+crI
 cqi
 ciZ
 ciZ
 ciZ
-cWz
+cMD
 cAl
 cEr
 cEr
@@ -99026,9 +91957,9 @@ ccw
 cpy
 ccw
 ccw
-cWz
-cWz
-cWz
+cMD
+cMD
+cMD
 cAl
 cEr
 cEr
@@ -99040,7 +91971,7 @@ cEr
 cEr
 cEr
 cHh
-cUv
+cAw
 cFb
 ccw
 cUq
@@ -99282,9 +92213,9 @@ cgR
 cgR
 cpD
 cDw
-cTU
-cTW
-cWz
+cqB
+cqU
+cMD
 cEt
 cAl
 csA
@@ -99539,9 +92470,9 @@ cgR
 cgR
 cpD
 cqb
-cTU
-cTW
-cWz
+cqB
+cqU
+cMD
 aaH
 cAl
 aaH
@@ -99794,13 +92725,13 @@ cmQ
 cny
 cgR
 cgR
-cTL
+cnx
 cqb
-cTU
-cTW
-cWz
+cqB
+cqU
+cMD
 aaH
-cUd
+cAn
 cUe
 cAr
 cUe
@@ -99811,7 +92742,7 @@ cUe
 cAr
 cUe
 cUe
-cUy
+cAx
 cFb
 ccw
 cUq
@@ -100053,7 +92984,7 @@ cgR
 cgR
 cen
 cqc
-cTT
+cqC
 crc
 ccw
 cEr
@@ -100309,7 +93240,7 @@ ckF
 cDe
 ckF
 cgw
-cMm
+cqa
 ccw
 ccw
 ccw
@@ -105639,11 +98570,11 @@ aJC
 aJC
 aJC
 aJC
-aXj
-aVy
-aSY
-aVy
-aVy
+AoF
+HzI
+elp
+UZd
+sKc
 aYI
 bah
 aJC
@@ -105890,17 +98821,17 @@ aaf
 alP
 aGJ
 aIe
-aJE
+Prn
 aKQ
-aLU
-aNu
+eLM
+Tar
 aJC
-aPw
-aQc
-aQc
-aSZ
-aQc
-aVy
+RCR
+aKR
+aKR
+fiD
+aKR
+fnE
 czP
 bag
 aJC
@@ -106152,12 +99083,12 @@ aJx
 aMi
 aNE
 aOO
-aQi
-aRz
-aSF
-aQc
-aQc
-aXl
+kxC
+kxC
+jrh
+kxC
+MTE
+Bii
 aKR
 bai
 aJC
@@ -106409,12 +99340,12 @@ aKz
 aKR
 aND
 aJC
-aPP
-aRg
-aQc
-aTa
-aQc
-aXk
+ftJ
+NnN
+dxG
+aKR
+uMd
+lfB
 aKR
 aKR
 aJC
@@ -106668,9 +99599,9 @@ aJC
 aJC
 aJI
 aJI
-aSI
 aJI
-aVA
+pms
+aJI
 aJI
 aYK
 aJI
@@ -108229,7 +101160,7 @@ bkR
 bfL
 boo
 bqQ
-cWs
+brj
 cWt
 bvn
 bwL
@@ -108743,7 +101674,7 @@ bla
 bmY
 bhh
 boq
-cWs
+brj
 cWv
 bsL
 bum
@@ -109000,7 +101931,7 @@ bkU
 bmX
 bpE
 cWr
-cWs
+brj
 cWw
 bti
 bul
@@ -115447,15 +108378,15 @@ bJO
 bWr
 bWr
 dbS
-dbN
-dbN
-dbN
-dbN
+bTo
+bTo
+bTo
+bTo
 bYj
 bZc
 bPN
-dbN
-dbN
+bTo
+bTo
 bQZ
 bNB
 ceM
@@ -115705,13 +108636,13 @@ bQX
 dbO
 bPN
 dbT
-dbN
+bTo
 bWp
-dbN
+bTo
 bYi
 dcg
 dck
-dbN
+bTo
 cbV
 bQZ
 blQ
@@ -115891,7 +108822,7 @@ cTZ
 alP
 cXs
 cXs
-dbH
+cYa
 cYn
 anf
 atB
@@ -115967,9 +108898,9 @@ dca
 bXl
 caZ
 cba
-dcl
+bSc
 cbc
-dbN
+bTo
 bQZ
 cdR
 ceO
@@ -116404,9 +109335,9 @@ aaa
 aaa
 alP
 cXs
-dbH
+cYa
 cXs
-dbH
+cYa
 auC
 alP
 alP
@@ -116477,9 +109408,9 @@ dbM
 bTl
 bQU
 dbW
-dbN
+bTo
 bOw
-dce
+bYk
 dci
 bPN
 cka
@@ -116736,8 +109667,8 @@ bSh
 dbW
 dcb
 bOv
-dce
-dcj
+bYk
+cbY
 bPN
 cjW
 dcs
@@ -116991,9 +109922,9 @@ bSi
 bTm
 bUn
 dbY
-dbN
+bTo
 bOw
-dce
+bYk
 bYm
 bZZ
 ckN
@@ -117434,7 +110365,7 @@ alP
 cXy
 dbI
 cXs
-dbH
+cYa
 anf
 alP
 cYW
@@ -117513,7 +110444,7 @@ cab
 cbd
 cbX
 ccT
-dcl
+bSc
 dcx
 cfu
 cgu
@@ -118015,11 +110946,11 @@ bNy
 bOH
 bEs
 bQY
-dbN
-dbN
-dbN
-dbN
-dbN
+bTo
+bTo
+bTo
+bTo
+bTo
 bXs
 bPL
 bQI
@@ -118271,18 +111202,18 @@ bMy
 bNx
 bOG
 bEs
-dbN
+bTo
 bSk
-dbN
-dbN
-dbN
-dbN
+bTo
+bTo
+bTo
+bTo
 bXr
 bPF
-dbN
-dbN
-dbN
-dcj
+bTo
+bTo
+bTo
+cbY
 bQZ
 cOe
 cNW
@@ -118529,11 +111460,11 @@ bNz
 bOI
 bEs
 bRa
-dbN
-dbN
-dbN
+bTo
+bTo
+bTo
 bVs
-dbN
+bTo
 bXt
 bPM
 bZh

--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -18,6 +18,9 @@
 "aac" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate)
+"aad" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/syndicate)
 "aae" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
@@ -2115,6 +2118,9 @@
 "aeE" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/pod_3)
+"aeF" = (
+/turf/closed/wall/mineral/titanium/overspace,
+/area/shuttle/pod_3)
 "aeG" = (
 /obj/structure/cable,
 /obj/machinery/power/solar{
@@ -2842,6 +2848,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"age" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "agf" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal{
@@ -2997,6 +3009,12 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"agv" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "agw" = (
 /obj/structure/table,
 /obj/machinery/syndicatebomb/training,
@@ -4782,6 +4800,15 @@
 /obj/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/labor)
+"ajY" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Unfiltered to Port";
+	on = 0
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ajZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -5978,6 +6005,9 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"amx" = (
+/turf/closed/wall,
+/area/maintenance/commiespy)
 "amy" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -7297,6 +7327,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"apv" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fitness Maitenance";
+	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "apw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -7465,6 +7509,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"apT" = (
+/obj/structure/chair/comfy/beige{
+	desc = "It looks comfy and extra tactical.\n<span class='notice'>Alt-click to rotate it clockwise.</span>";
+	dir = 1;
+	icon_state = "comfychair";
+	name = "tactical armchair"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "apU" = (
 /turf/open/floor/plating,
 /area/security/vacantoffice/b)
@@ -7891,6 +7944,18 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
+"aqU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Cargo Technician"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "aqV" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -7967,6 +8032,10 @@
 "arf" = (
 /turf/closed/wall,
 /area/crew_quarters/dorms)
+"arg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/maintenance/department/crew_quarters/dorms)
 "arh" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Dormitories Maintenance";
@@ -8233,6 +8302,15 @@
 "arP" = (
 /turf/closed/wall,
 /area/maintenance/fore)
+"arQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/eva)
 "arR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 2;
@@ -8445,6 +8523,18 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"asq" = (
+/obj/machinery/camera{
+	c_tag = "Fitness Room"
+	},
+/obj/structure/closet/masks,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral/side{
+	dir = 1
+	},
+/area/crew_quarters/fitness)
 "asr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -8674,6 +8764,12 @@
 	},
 /turf/open/floor/plating,
 /area/hippie/pool)
+"asZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/yellowsiding/corner{
+	dir = 8
+	},
+/area/hippie/pool)
 "ata" = (
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -8873,6 +8969,10 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/fore)
+"atz" = (
+/mob/living/simple_animal/mouse,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "atA" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -9195,6 +9295,31 @@
 	},
 /turf/open/pool,
 /area/hippie/pool)
+"aut" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/crew_quarters/fitness)
+"auu" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"auv" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/crew_quarters/fitness)
 "auw" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -9295,6 +9420,14 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"auH" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -9635,16 +9768,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"avw" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/neutral/side{
+	dir = 8
+	},
+/area/crew_quarters/fitness)
 "avx" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/hippie/pool)
+"avy" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
+/area/crew_quarters/fitness)
 "avz" = (
 /obj/machinery/drain,
 /obj/item/bikehorn/rubberducky,
 /turf/open/pool,
 /area/hippie/pool)
+"avA" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/crew_quarters/fitness)
 "avB" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -10099,6 +10250,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"awy" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "awz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -10387,6 +10542,10 @@
 	dir = 4
 	},
 /area/construction/mining/aux_base)
+"axd" = (
+/mob/living/simple_animal/mouse,
+/turf/open/floor/plating,
+/area/maintenance/arrivals/north)
 "axe" = (
 /obj/machinery/sleeper{
 	dir = 4;
@@ -10740,6 +10899,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/hippie/pool)
+"axS" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8;
+	on = 1;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/crew_quarters/fitness)
+"axT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"axU" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/black,
+/area/crew_quarters/fitness)
 "axV" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -10748,6 +10940,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"axW" = (
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	icon_state = "left";
+	name = "Fitness Ring"
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/black,
+/area/crew_quarters/fitness)
 "axX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -10757,6 +10958,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"axY" = (
+/turf/open/floor/plasteel/green/side{
+	dir = 4
+	},
+/area/crew_quarters/fitness)
 "axZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -10774,6 +10980,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hippie/pool)
+"ayb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "ayc" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -11234,6 +11446,10 @@
 "aze" = (
 /turf/open/floor/plasteel/neutral/side,
 /area/crew_quarters/dorms)
+"azf" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "azg" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -11258,6 +11474,58 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"azj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel/neutral/side{
+	dir = 10
+	},
+/area/crew_quarters/fitness)
+"azk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"azl" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 8
+	},
+/area/crew_quarters/fitness)
+"azm" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"azn" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"azo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "azp" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -11656,6 +11924,72 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 1
+	},
+/area/hippie/pool)
+"aAl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 1
+	},
+/area/hippie/pool)
+"aAm" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 1
+	},
+/area/hippie/pool)
+"aAn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_y = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral/side,
+/area/crew_quarters/fitness)
+"aAo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 1
 	},
@@ -12459,6 +12793,12 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"aCf" = (
+/obj/machinery/camera{
+	c_tag = "Theatre Storage"
+	},
+/turf/open/floor/plasteel/purple,
+/area/crew_quarters/theatre)
 "aCg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12468,6 +12808,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"aCh" = (
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/plasteel/purple,
+/area/crew_quarters/theatre)
 "aCi" = (
 /obj/structure/grille,
 /obj/structure/cable,
@@ -12542,6 +12886,17 @@
 	dir = 4
 	},
 /area/hallway/secondary/entry)
+"aCq" = (
+/obj/structure/table/wood,
+/obj/machinery/requests_console{
+	department = "Theatre";
+	departmentType = 0;
+	name = "theatre RC";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/purple,
+/area/crew_quarters/theatre)
 "aCr" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
@@ -12574,6 +12929,14 @@
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/hippie/pool)
+"aCw" = (
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -12996,6 +13359,11 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
+"aDu" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "aDv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -13132,6 +13500,14 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
+"aDJ" = (
+/obj/structure/table,
+/obj/item/device/flashlight/lamp{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "aDK" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm1";
@@ -13376,6 +13752,16 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
+"aEi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Chapel Maintenance";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "aEj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
@@ -13820,6 +14206,16 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"aFj" = (
+/turf/open/floor/plasteel/purple,
+/area/crew_quarters/theatre)
+"aFk" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/plasteel/purple,
+/area/crew_quarters/theatre)
 "aFl" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -13946,6 +14342,19 @@
 /turf/open/floor/plating,
 /area/chapel/office)
 "aFz" = (
+/turf/open/floor/plasteel/black,
+/area/chapel/main)
+"aFA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/computer/pod/old{
+	density = 0;
+	icon = 'icons/obj/airlock_machines.dmi';
+	icon_state = "airlock_control_standby";
+	id = "chapelgun";
+	name = "Mass Driver Controller";
+	pixel_x = 24;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
 "aFB" = (
@@ -14440,6 +14849,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"aGD" = (
+/obj/structure/table/wood,
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/purple,
+/area/crew_quarters/theatre)
 "aGE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -14492,6 +14908,21 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"aGI" = (
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j1";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -14763,6 +15194,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
+"aHi" = (
+/obj/structure/closet/coffin,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
+/area/chapel/office)
 "aHj" = (
 /obj/machinery/light_switch{
 	pixel_x = -20;
@@ -14785,6 +15223,14 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
+"aHl" = (
+/obj/structure/closet/coffin,
+/obj/machinery/door/window/eastleft{
+	name = "Coffin Storage";
+	req_access_txt = "22"
+	},
+/turf/open/floor/plasteel/black,
+/area/chapel/office)
 "aHm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -14831,6 +15277,12 @@
 "aHs" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Arrivals Shuttle Airlock"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/arrival)
+"aHt" = (
+/obj/effect/landmark{
+	name = "Observer-Start"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
@@ -14959,10 +15411,17 @@
 	dir = 4
 	},
 /area/crew_quarters/dorms)
+"aHI" = (
+/turf/open/floor/plasteel/purple,
+/area/crew_quarters/theatre)
 "aHJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/gateway)
+"aHK" = (
+/obj/structure/closet/secure_closet/freezer/cream_pie,
+/turf/open/floor/plasteel/purple,
+/area/crew_quarters/theatre)
 "aHL" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -15132,6 +15591,13 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
+"aId" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "aIe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -15176,6 +15642,12 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
+/area/crew_quarters/kitchen)
+"aIi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
 /area/crew_quarters/kitchen)
 "aIj" = (
 /obj/structure/cable{
@@ -15362,6 +15834,10 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/chapel/office)
+"aIE" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/chapel,
+/area/chapel/main)
 "aIF" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -15632,6 +16108,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"aJk" = (
+/obj/machinery/door/airlock{
+	name = "Theatre Backstage";
+	req_access_txt = "46"
+	},
+/turf/open/floor/plasteel/purple,
+/area/crew_quarters/theatre)
 "aJl" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/machinery/light{
@@ -15770,6 +16253,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"aJE" = (
+/obj/structure/table/wood,
+/obj/item/gun/ballistic/revolver/doublebarrel{
+	desc = "The barkeeper's trusty double-barrel. Works beautifully, despite its age.";
+	name = "Ol' Faithful"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "aJF" = (
 /obj/machinery/newscaster{
 	pixel_x = 30
@@ -16547,6 +17038,28 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/chapel/main)
+"aLs" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Arrivals Shuttle Airlock"
+	},
+/obj/docking_port/mobile{
+	dwidth = 5;
+	height = 7;
+	id = "arrival";
+	name = "arrival shuttle";
+	port_direction = 8;
+	preferred_direction = 8;
+	width = 15
+	},
+/obj/docking_port/stationary{
+	dwidth = 5;
+	height = 7;
+	id = "arrival_home";
+	name = "port bay 1";
+	width = 15
+	},
+/turf/open/floor/plating,
+/area/shuttle/arrival)
 "aLt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -16750,6 +17263,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"aLU" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "aLV" = (
 /obj/machinery/light{
 	dir = 1
@@ -17040,6 +17564,15 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/office)
+"aML" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 4;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/chapel/main)
 "aMM" = (
 /obj/machinery/camera{
 	c_tag = "Chapel North";
@@ -17267,6 +17800,11 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"aNu" = (
+/obj/structure/closet/secure_closet/bar,
+/obj/item/book/manual/barman_recipes,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "aNv" = (
 /turf/open/floor/plasteel{
 	icon = 'hippiestation/icons/turf/floors.dmi';
@@ -17325,6 +17863,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aND" = (
+/obj/structure/closet/gmcloset,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/cable_coil,
+/obj/item/device/flashlight/lamp,
+/obj/item/device/flashlight/lamp/green,
+/obj/item/screwdriver,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "aNE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -17483,6 +18035,16 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/office)
+"aNX" = (
+/obj/item/device/radio/intercom{
+	broadcasting = 1;
+	frequency = 1480;
+	name = "Confessional Intercom";
+	pixel_x = 25
+	},
+/obj/structure/chair,
+/turf/open/floor/plasteel/black,
+/area/chapel/main)
 "aNY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -17490,11 +18052,40 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
+"aNZ" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel/red/side{
+	dir = 9
+	},
+/area/hallway/secondary/exit)
+"aOa" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/chair,
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/hallway/secondary/exit)
 "aOb" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
+/area/hallway/secondary/exit)
+"aOc" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"aOd" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aOe" = (
 /obj/item/device/radio/beacon,
@@ -18014,6 +18605,25 @@
 	dir = 1
 	},
 /area/chapel/main)
+"aPo" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted/fulltile,
+/turf/open/floor/plasteel/black,
+/area/chapel/main)
+"aPp" = (
+/obj/machinery/camera{
+	c_tag = "Escape Arm Holding Area";
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/hallway/secondary/exit)
 "aPq" = (
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -18055,6 +18665,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"aPw" = (
+/obj/structure/sign/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
+	pixel_x = -28;
+	pixel_y = -4
+	},
+/obj/machinery/button/door{
+	id = "barShutters";
+	name = "bar shutters";
+	pixel_x = 4;
+	pixel_y = 28
+	},
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "aPx" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1;
@@ -18155,6 +18782,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"aPP" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/chem_dispenser/drinks/beer,
+/obj/item/device/radio/intercom{
+	pixel_y = 25
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "aPQ" = (
 /turf/closed/wall,
 /area/storage/tools)
@@ -18296,6 +18935,14 @@
 /obj/item/device/instrument/violin,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"aQc" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/structure/reagent_dispensers/chemical,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "aQd" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/assistant,
@@ -18327,6 +18974,10 @@
 	dir = 5
 	},
 /area/hydroponics)
+"aQi" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "aQj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -18422,6 +19073,24 @@
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
+/area/chapel/main)
+"aQz" = (
+/obj/item/device/radio/intercom{
+	broadcasting = 1;
+	frequency = 1480;
+	name = "Confessional Intercom";
+	pixel_x = 25
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/chapel/main)
+"aQA" = (
+/obj/machinery/door/morgue{
+	name = "Confession Booth"
+	},
+/turf/open/floor/plasteel/black,
 /area/chapel/main)
 "aQB" = (
 /turf/open/floor/plasteel/red/side,
@@ -18619,6 +19288,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"aRg" = (
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/table/reinforced,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "aRh" = (
 /obj/machinery/light{
 	dir = 8
@@ -18749,6 +19423,13 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"aRz" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/open/floor/plasteel/bar,
+/area/crew_quarters/bar)
 "aRA" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/cafeteria,
@@ -18964,6 +19645,14 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"aSb" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "aSc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -19159,6 +19848,11 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel,
 /area/bridge)
+"aSF" = (
+/obj/structure/disposalpipe/segment,
+/mob/living/carbon/monkey/punpun,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "aSG" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
@@ -19174,6 +19868,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"aSI" = (
+/obj/machinery/door/airlock/glass{
+	name = "Kitchen";
+	req_access_txt = "28"
+	},
+/turf/open/floor/plasteel/bar,
+/area/crew_quarters/kitchen)
 "aSJ" = (
 /obj/effect/landmark/start/cook,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19290,6 +19991,34 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"aSY" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that{
+	throwforce = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"aSZ" = (
+/obj/effect/landmark/start/bartender,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"aTa" = (
+/obj/machinery/requests_console{
+	department = "Bar";
+	departmentType = 2;
+	pixel_x = 30;
+	pixel_y = 0;
+	receive_ore_updates = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Bar";
+	dir = 8;
+	network = list("SS13")
+	},
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks,
+/turf/open/floor/plasteel/bar,
+/area/crew_quarters/bar)
 "aTb" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -19372,6 +20101,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"aTn" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
+	name = "Escape Airlock"
+	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "aTo" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 8;
@@ -19379,6 +20123,9 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"aTp" = (
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "aTq" = (
 /turf/closed/wall,
 /area/hippie/clown)
@@ -19794,6 +20541,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"aUy" = (
+/obj/machinery/camera{
+	c_tag = "Vacant Office";
+	dir = 4;
+	network = list("SS13")
+	},
+/turf/open/floor/wood,
+/area/security/vacantoffice)
 "aUz" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/airalarm{
@@ -19803,6 +20558,11 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/hydroponics)
+"aUA" = (
+/obj/structure/table/wood,
+/obj/item/device/flashlight/lamp,
+/turf/open/floor/wood,
+/area/security/vacantoffice)
 "aUB" = (
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/wood,
@@ -19870,6 +20630,14 @@
 	dir = 8
 	},
 /area/hallway/secondary/exit)
+"aUM" = (
+/obj/machinery/camera{
+	c_tag = "Arrivals Bay 2";
+	dir = 8;
+	network = list("SS13")
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "aUN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/cafeteria,
@@ -19881,9 +20649,21 @@
 	},
 /turf/open/floor/plasteel/redyellow,
 /area/hippie/clown)
+"aUP" = (
+/obj/machinery/airalarm{
+	frequency = 1439;
+	pixel_y = 23
+	},
+/turf/open/floor/wood,
+/area/security/vacantoffice)
 "aUQ" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/hippie/mime)
+"aUR" = (
+/obj/structure/table/wood,
+/obj/item/pen/red,
+/turf/open/floor/wood,
+/area/security/vacantoffice)
 "aUS" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -19919,6 +20699,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"aUW" = (
+/obj/structure/table/wood,
+/obj/item/device/flashlight/lamp/green,
+/turf/open/floor/wood,
+/area/security/vacantoffice)
 "aUX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -20224,7 +21009,18 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"aVy" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "aVz" = (
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"aVA" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/reagent_containers/food/snacks/pie/cream,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aVB" = (
@@ -20550,6 +21346,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"aWm" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_x = -28;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/security/vacantoffice)
 "aWn" = (
 /obj/structure/closet/wardrobe/black,
 /obj/item/clothing/shoes/jackboots,
@@ -20598,6 +21405,12 @@
 /obj/structure/closet/crate/wooden/toy,
 /turf/open/floor/plasteel/redyellow,
 /area/hippie/clown)
+"aWt" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/vacantoffice)
 "aWu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -21079,6 +21892,31 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"aXj" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/machinery/camera{
+	c_tag = "Bar";
+	dir = 2;
+	network = list("SS13")
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"aXk" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"aXl" = (
+/obj/machinery/door/window/southright{
+	name = "Bar Door";
+	req_access_txt = "0";
+	req_one_access_txt = "25;28"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "aXm" = (
 /obj/effect/landmark/start/cook,
 /turf/open/floor/plasteel/cafeteria,
@@ -21207,6 +22045,12 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/closed/wall,
 /area/maintenance/port)
+"aXF" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/crew_quarters/fitness)
 "aXG" = (
 /obj/machinery/light{
 	dir = 4;
@@ -21217,6 +22061,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"aXH" = (
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "syndieshutters";
+	name = "remote shutter control";
+	req_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "aXI" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 4;
@@ -21278,6 +22131,15 @@
 /obj/item/storage/crayons,
 /turf/open/floor/plasteel/redyellow,
 /area/hippie/clown)
+"aXO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/plasteel/bar,
+/area/crew_quarters/bar)
 "aXP" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -22445,6 +23307,17 @@
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"baG" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	pixel_y = 0
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -23796,6 +24669,10 @@
 /obj/structure/closet/crate/medical,
 /turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/storage)
+"bdV" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "bdW" = (
 /obj/item/clothing/gloves/color/rainbow,
 /obj/item/clothing/head/soft/rainbow,
@@ -24697,6 +25574,13 @@
 	dir = 10
 	},
 /area/hallway/secondary/exit)
+"bgf" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "bgg" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/escape{
@@ -25416,6 +26300,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"bhK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/mechbay)
 "bhL" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 1;
@@ -25449,6 +26345,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"bhP" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8;
+	on = 1;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/plasteel/white,
+/area/science/robotics/lab)
 "bhQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -25837,6 +26741,15 @@
 "biL" = (
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"biM" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Roboticist"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/robotics/lab)
 "biN" = (
 /turf/open/floor/plasteel/whitered/side{
 	dir = 1
@@ -25956,6 +26869,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"biZ" = (
+/obj/machinery/computer/shuttle/syndicate,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "bja" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -26227,6 +27144,18 @@
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"bjD" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Bridge Maintenance APC";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "bjE" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -26386,6 +27315,15 @@
 	dir = 2
 	},
 /area/medical/medbay/central)
+"bjW" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/science/robotics/mechbay)
 "bjX" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -26460,6 +27398,14 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
+"bkg" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/circuit,
+/area/science/robotics/mechbay)
 "bkh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/circuit,
@@ -26502,6 +27448,23 @@
 	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/science/robotics/lab)
+"bkl" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_research{
+	name = "Robotics Lab";
+	req_access_txt = "29"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bkm" = (
@@ -27303,6 +28266,10 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"blN" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/science/robotics/lab)
 "blO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -27873,6 +28840,26 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
+/area/science/robotics/mechbay)
+"bnd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/science/robotics/mechbay)
+"bne" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bnf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -28493,6 +29480,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"bop" = (
+/obj/machinery/mech_bay_recharge_port,
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/floor/plating,
+/area/science/robotics/mechbay)
 "boq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
@@ -28519,6 +29514,14 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
+/area/science/robotics/lab)
+"bot" = (
+/obj/structure/grille,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
 /area/science/robotics/lab)
 "bou" = (
 /turf/open/floor/plasteel,
@@ -29307,6 +30310,21 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/science/robotics/lab)
+"bqb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/mechbay)
 "bqc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/white,
@@ -29808,6 +30826,17 @@
 	},
 /turf/closed/wall,
 /area/medical/genetics)
+"bri" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	dir = 2
+	},
+/area/medical/medbay/central)
 "brj" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -29824,6 +30853,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"brl" = (
+/obj/machinery/light_switch{
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/robotics/lab)
 "brm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30523,6 +31562,10 @@
 	dir = 9
 	},
 /area/science/research)
+"bsB" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "bsC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
@@ -30598,6 +31641,14 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard)
+"bsK" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/disks{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "bsL" = (
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -30789,6 +31840,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"btk" = (
+/obj/structure/closet/wardrobe/white,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "btl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	on = 1;
@@ -31245,6 +32300,15 @@
 	dir = 5
 	},
 /area/medical/genetics)
+"bug" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
+"buh" = (
+/turf/closed/wall/r_wall,
+/area/science/robotics/mechbay)
 "bui" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -31439,6 +32503,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"buA" = (
+/obj/structure/frame/computer,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "buB" = (
 /obj/machinery/conveyor_switch/oneway{
 	convdir = -1;
@@ -32420,6 +33488,11 @@
 /obj/structure/sign/nosmoking_2,
 /turf/closed/wall,
 /area/medical/sleeper)
+"bwH" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel,
+/area/medical/sleeper)
 "bwI" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/plasteel,
@@ -32512,6 +33585,14 @@
 	dir = 9
 	},
 /area/science/research)
+"bwP" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "bwQ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -32729,6 +33810,41 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"bxh" = (
+/obj/machinery/door/poddoor{
+	id = "smindicate";
+	name = "outer blast door"
+	},
+/obj/machinery/button/door{
+	id = "smindicate";
+	name = "external door control";
+	pixel_x = -26;
+	pixel_y = 0;
+	req_access_txt = "150"
+	},
+/obj/docking_port/mobile{
+	dheight = 9;
+	dir = 2;
+	dwidth = 5;
+	height = 24;
+	id = "syndicate";
+	name = "syndicate infiltrator";
+	port_direction = 1;
+	roundstart_move = "syndicate_away";
+	width = 18
+	},
+/obj/docking_port/stationary{
+	dheight = 9;
+	dir = 2;
+	dwidth = 5;
+	height = 24;
+	id = "syndicate_nw";
+	name = "northwest of station";
+	turf_type = /turf/open/space;
+	width = 18
+	},
+/turf/open/floor/plating,
+/area/shuttle/syndicate)
 "bxi" = (
 /obj/machinery/computer/aifixer,
 /obj/machinery/requests_console{
@@ -33032,6 +34148,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
+"bxS" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/medical/sleeper)
 "bxT" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -33069,6 +34191,13 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"bxX" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "bxY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34848,6 +35977,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"bBM" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/obj/item/device/multitool,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "bBN" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/cmo)
@@ -35845,6 +36982,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"bDX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/mob/living/simple_animal/mouse,
+/turf/open/floor/plasteel/floorgrime,
+/area/science/storage)
 "bDY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -37534,6 +38681,14 @@
 	dir = 8
 	},
 /area/quartermaster/miningdock)
+"bHB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/mob/living/simple_animal/mouse,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "bHC" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -39876,6 +41031,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"bMf" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
+/obj/item/stack/cable_coil,
+/obj/item/device/multitool,
+/obj/item/stock_parts/cell/high/plus,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "bMg" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -40248,6 +41416,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"bNa" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
 "bNb" = (
 /obj/item/airlock_painter,
 /obj/structure/lattice,
@@ -40261,6 +41436,16 @@
 "bNd" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
+"bNe" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "bNf" = (
 /obj/structure/sign/biohazard,
 /turf/closed/wall,
@@ -40649,6 +41834,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"bNX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/science/misc_lab)
 "bNY" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41768,6 +42961,14 @@
 /obj/structure/closet/wardrobe/virology_white,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"bQG" = (
+/obj/structure/grille,
+/obj/structure/window/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/misc_lab)
 "bQH" = (
 /obj/structure/closet/l3closet,
 /obj/effect/turf_decal/stripes/line{
@@ -41870,6 +43071,18 @@
 	},
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
+"bQS" = (
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	dir = 2;
+	name = "Science Requests Console";
+	pixel_x = 0;
+	pixel_y = 30;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "bQT" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -41933,6 +43146,13 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"bRc" = (
+/obj/structure/table/wood,
+/obj/item/soap/nanotrasen,
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/maintenance/port/aft)
 "bRd" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/bar,
@@ -42411,6 +43631,10 @@
 /obj/item/device/assembly/signaler,
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
+"bSf" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/floorgrime,
+/area/science/misc_lab)
 "bSg" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
@@ -42473,6 +43697,10 @@
 "bSn" = (
 /obj/structure/chair/stool,
 /turf/open/floor/carpet/black,
+/area/maintenance/port/aft)
+"bSo" = (
+/obj/structure/chair/stool,
+/turf/open/floor/wood,
 /area/maintenance/port/aft)
 "bSp" = (
 /obj/structure/grille/broken,
@@ -43001,6 +44229,12 @@
 "bTo" = (
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
+"bTp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "bTq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -43403,6 +44637,14 @@
 	receive_ore_updates = 1
 	},
 /turf/open/floor/plasteel/vault,
+/area/science/misc_lab)
+"bUk" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10;
+	pixel_x = 0;
+	initialize_directions = 10
+	},
+/turf/open/floor/plasteel,
 /area/science/misc_lab)
 "bUl" = (
 /obj/structure/disposalpipe/sortjunction{
@@ -43907,6 +45149,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"bVn" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4;
+	initialize_directions = 11
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/floorgrime,
+/area/science/misc_lab)
 "bVo" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -44343,6 +45593,12 @@
 	},
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
+"bWq" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/science/misc_lab)
 "bWr" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault,
@@ -44725,6 +45981,33 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/vault,
+/area/science/misc_lab)
+"bXi" = (
+/obj/structure/table,
+/obj/item/folder/white,
+/obj/item/folder/white,
+/obj/item/pen,
+/obj/item/device/taperecorder{
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/science/misc_lab)
+"bXj" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/button/ignition{
+	id = "testigniter";
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/machinery/button/door{
+	id = "testlab";
+	name = "Test Chamber Blast Doors";
+	pixel_x = 4;
+	pixel_y = 2;
+	req_access_txt = "55"
+	},
+/turf/open/floor/plasteel/floorgrime,
 /area/science/misc_lab)
 "bXk" = (
 /obj/machinery/navbeacon{
@@ -45970,6 +47253,12 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"bZY" = (
+/obj/item/device/radio/intercom{
+	pixel_x = -25
+	},
+/turf/open/floor/engine,
+/area/science/misc_lab)
 "bZZ" = (
 /obj/structure/sign/radiation,
 /turf/closed/wall,
@@ -46512,6 +47801,10 @@
 /obj/item/grenade/chem_grenade,
 /obj/item/reagent_containers/spray,
 /turf/open/floor/plasteel/vault,
+/area/science/misc_lab)
+"caY" = (
+/obj/item/device/radio/beacon,
+/turf/open/floor/engine,
 /area/science/misc_lab)
 "caZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -47921,6 +49214,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cdP" = (
+/obj/machinery/door/window{
+	name = "Ready Room";
+	req_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "cdQ" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb,
@@ -47930,6 +49230,15 @@
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cdS" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel{
+	dir = 2
+	},
+/area/science/misc_lab)
 "cdT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -48458,6 +49767,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"cff" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/yellow/corner{
+	dir = 1
+	},
+/area/engine/engineering)
 "cfg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -48611,11 +49926,36 @@
 	dir = 1
 	},
 /area/engine/engineering)
+"cfA" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cfB" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
+/area/engine/engineering)
+"cfC" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cfD" = (
 /obj/structure/disposalpipe/segment,
@@ -49041,6 +50381,12 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cgx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "cgy" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -49134,6 +50480,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"cgI" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cgJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cgK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -49166,11 +50526,27 @@
 	dir = 2
 	},
 /area/crew_quarters/heads/chief)
+"cgN" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cgO" = (
 /turf/open/floor/plasteel/neutral{
 	dir = 2
 	},
 /area/crew_quarters/heads/chief)
+"cgP" = (
+/obj/structure/table,
+/obj/item/device/flashlight{
+	pixel_y = 5
+	},
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/airlock_painter,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cgQ" = (
 /obj/machinery/camera{
 	c_tag = "Engineering East";
@@ -49711,6 +51087,51 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"chU" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/mouse,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"chV" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/glasses/meson/engine,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"chW" = (
+/obj/machinery/camera{
+	c_tag = "Engineering Center";
+	dir = 2;
+	pixel_x = 23
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "chX" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -49721,6 +51142,12 @@
 /area/engine/engineering)
 "chY" = (
 /obj/machinery/shieldgen,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"chZ" = (
+/obj/machinery/the_singularitygen{
+	anchored = 0
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cia" = (
@@ -49815,6 +51242,27 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
+"cii" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/glasses/meson,
+/obj/item/device/geiger_counter,
+/obj/item/device/geiger_counter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cij" = (
 /obj/machinery/computer/station_alert,
 /obj/item/device/radio/intercom{
@@ -49853,6 +51301,15 @@
 	dir = 2
 	},
 /area/crew_quarters/heads/chief)
+"cil" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/storage/belt/utility,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cim" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -49881,12 +51338,29 @@
 	dir = 2
 	},
 /area/crew_quarters/heads/chief)
+"cip" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "ciq" = (
 /obj/structure/grille,
 /obj/structure/cable,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
+"cir" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cis" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -50109,6 +51583,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"ciV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ciW" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -50217,6 +51702,12 @@
 	dir = 2
 	},
 /area/crew_quarters/heads/chief)
+"cjh" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cji" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -50275,6 +51766,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cjn" = (
+/obj/item/weldingtool,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cjo" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plasteel,
@@ -50565,6 +52060,10 @@
 	dir = 2
 	},
 /area/crew_quarters/heads/chief)
+"cjZ" = (
+/obj/structure/sign/securearea,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "cka" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -51311,6 +52810,22 @@
 /obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"clK" = (
+/obj/item/device/radio/intercom{
+	desc = "Talk through this. Evilly";
+	freerange = 1;
+	frequency = 1213;
+	name = "Syndicate Intercom";
+	pixel_y = -32;
+	subspace_transmission = 1;
+	syndie = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
+"clL" = (
+/obj/structure/closet/syndicate/personal,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "clM" = (
 /obj/structure/table,
 /obj/item/crowbar/large,
@@ -51388,6 +52903,13 @@
 "clZ" = (
 /turf/open/floor/engine/air,
 /area/engine/atmos)
+"cma" = (
+/obj/machinery/door/window{
+	name = "Cockpit";
+	req_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "cmb" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -51469,6 +52991,13 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"cmm" = (
+/obj/structure/chair{
+	dir = 8;
+	name = "tactical chair"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "cmn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -51648,6 +53177,26 @@
 	dir = 9
 	},
 /area/engine/engineering)
+"cmH" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/item/crowbar/red,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
+"cmI" = (
+/obj/machinery/vending/engivend,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/engine/engineering)
+"cmJ" = (
+/obj/structure/table,
+/obj/item/storage/box/zipties{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "cmK" = (
 /obj/machinery/requests_console{
 	announcementConsole = 0;
@@ -51675,6 +53224,12 @@
 	dir = 1
 	},
 /area/engine/engineering)
+"cmM" = (
+/obj/machinery/sleeper/syndie{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/syndicate)
 "cmN" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_y = 32
@@ -51689,6 +53244,13 @@
 	dir = 1
 	},
 /area/engine/engineering)
+"cmO" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/syndicate)
+"cmP" = (
+/turf/open/floor/mineral/titanium,
+/area/shuttle/syndicate)
 "cmQ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -51712,6 +53274,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cmS" = (
+/obj/structure/table,
+/obj/item/stack/medical/ointment,
+/obj/item/stack/medical/bruise_pack,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -5;
+	pixel_y = 30
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/syndicate)
+"cmT" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "cmU" = (
 /obj/machinery/light/small,
 /turf/open/floor/engine/n2,
@@ -51830,6 +53406,12 @@
 /obj/item/clipboard,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"cnh" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "cni" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -51957,6 +53539,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cns" = (
+/obj/structure/closet/syndicate/nuclear,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "cnt" = (
 /obj/machinery/camera{
 	c_tag = "Engineering West";
@@ -51973,6 +53559,11 @@
 	dir = 1
 	},
 /area/engine/engineering)
+"cnu" = (
+/obj/structure/table,
+/obj/item/device/aicard,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "cnv" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -52011,6 +53602,10 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cnz" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/syndicate)
 "cnA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -52090,6 +53685,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cnI" = (
+/obj/structure/table,
+/obj/item/grenade/plastic/c4{
+	pixel_x = 2;
+	pixel_y = -5
+	},
+/obj/item/grenade/plastic/c4{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/grenade/plastic/c4{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/grenade/plastic/c4{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/grenade/plastic/c4{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "cnJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -52222,6 +53841,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"cnT" = (
+/obj/structure/sign/bluecross_2,
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate)
 "cnU" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -52240,6 +53863,10 @@
 	},
 /turf/open/floor/plasteel/loadingarea,
 /area/engine/engineering)
+"cnV" = (
+/obj/structure/bed/roller,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/syndicate)
 "cnW" = (
 /turf/open/space,
 /turf/closed/wall/mineral/plastitanium{
@@ -52318,8 +53945,48 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"coc" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cod" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/syndicate)
+"coe" = (
+/obj/machinery/door/window{
+	dir = 4;
+	name = "EVA Storage";
+	req_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "cof" = (
 /obj/machinery/door/airlock/external{
+	req_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
+"cog" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "EVA Storage";
 	req_access_txt = "150"
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -52328,6 +53995,64 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
+/area/shuttle/syndicate)
+"coi" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/space/syndicate/black/red,
+/obj/item/clothing/head/helmet/space/syndicate/black/red,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
+"coj" = (
+/obj/item/device/radio/intercom{
+	desc = "Talk through this. Evilly";
+	freerange = 1;
+	frequency = 1213;
+	name = "Syndicate Intercom";
+	pixel_x = -32;
+	subspace_transmission = 1;
+	syndie = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
+"cok" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
+"col" = (
+/obj/machinery/door/window{
+	dir = 4;
+	name = "Infirmary";
+	req_access_txt = "150"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/syndicate)
+"com" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Infirmary";
+	req_access_txt = "150"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/syndicate)
+"con" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/bodypart/r_arm/robot,
+/obj/item/bodypart/l_arm/robot,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/syndicate)
+"coo" = (
+/obj/structure/table,
+/obj/item/stock_parts/cell/high{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/stock_parts/cell/high,
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate)
 "cop" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -52504,6 +54229,44 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"coD" = (
+/obj/structure/table,
+/obj/item/wrench,
+/obj/item/device/assembly/infra,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
+"coE" = (
+/obj/structure/table,
+/obj/item/screwdriver{
+	pixel_y = 9
+	},
+/obj/item/device/assembly/voice{
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
+"coF" = (
+/obj/structure/table,
+/obj/item/weldingtool/largetank{
+	pixel_y = 3
+	},
+/obj/item/device/multitool,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
+"coG" = (
+/obj/structure/table,
+/obj/item/device/assembly/signaler,
+/obj/item/device/assembly/signaler,
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "coH" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -52515,6 +54278,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"coI" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/syndicate)
 "coJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -52554,6 +54323,66 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"coM" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"coN" = (
+/obj/machinery/door/window/westright{
+	name = "Tool Storage";
+	req_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
+"coO" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/crowbar/red,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
+"coP" = (
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Surgery";
+	req_access_txt = "150"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/syndicate)
+"coQ" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/syndicate)
+"coR" = (
+/obj/machinery/door/window{
+	dir = 8;
+	name = "Tool Storage";
+	req_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "coS" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser{
@@ -52585,6 +54414,52 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"coU" = (
+/obj/structure/table,
+/obj/item/surgicaldrill,
+/obj/item/circular_saw,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/syndicate)
+"coV" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/structure/mirror{
+	pixel_x = 30
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/syndicate)
+"coW" = (
+/obj/structure/table,
+/obj/item/device/sbeacondrop/bomb{
+	pixel_y = 5
+	},
+/obj/item/device/sbeacondrop/bomb,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
+"coX" = (
+/obj/structure/table,
+/obj/item/grenade/syndieminibomb{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/grenade/syndieminibomb{
+	pixel_x = -1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
+"coY" = (
+/obj/machinery/nuclearbomb/syndicate,
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Secure Storage";
+	req_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "coZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -52627,6 +54502,12 @@
 	},
 /turf/open/space,
 /area/space)
+"cpf" = (
+/obj/machinery/telecomms/allinone{
+	intercept = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "cpg" = (
 /obj/item/grenade/barrier{
 	pixel_x = 4
@@ -52739,6 +54620,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cpr" = (
+/obj/structure/table,
+/obj/item/cautery,
+/obj/item/scalpel,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/syndicate)
 "cps" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass{
@@ -52782,6 +54669,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cpw" = (
+/obj/structure/table,
+/obj/item/retractor,
+/obj/item/hemostat,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/syndicate)
+"cpx" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cpy" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -52810,6 +54712,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"cpB" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cpC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/landmark/event_spawn,
@@ -52835,11 +54748,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cpF" = (
+/obj/structure/table/optable,
+/obj/item/surgical_drapes,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/syndicate)
 "cpG" = (
 /obj/structure/table/optable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"cpH" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/syndicate)
 "cpI" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 4;
@@ -53060,6 +54985,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cqe" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	icon_state = "intact";
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cqf" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -53097,6 +55035,34 @@
 "cqj" = (
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plating,
+/area/engine/engineering)
+"cqk" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cql" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cqm" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqn" = (
 /obj/structure/grille,
@@ -53240,10 +55206,18 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cqD" = (
+/obj/structure/sign/radiation,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "cqE" = (
 /obj/structure/particle_accelerator/power_box,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cqF" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "cqG" = (
 /obj/structure/rack,
 /obj/item/storage/box/rubbershot{
@@ -53273,6 +55247,12 @@
 /obj/item/screwdriver,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cqI" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion_l"
+	},
+/turf/open/floor/plating,
+/area/shuttle/syndicate)
 "cqJ" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -53367,6 +55347,35 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cqV" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cqW" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/item/tank/internals/plasma,
+/obj/structure/cable/yellow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cqX" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cqY" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -53395,6 +55404,31 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cre" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"crf" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion_r"
+	},
+/turf/open/floor/plating,
+/area/shuttle/syndicate)
+"crg" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating,
+/area/shuttle/syndicate)
 "crh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -53408,6 +55442,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"crj" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard)
 "crk" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -53487,6 +55532,19 @@
 /obj/item/wirecutters,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cru" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"crv" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "crw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -53608,6 +55666,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/aft)
+"crH" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
 "crI" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -53617,6 +55681,13 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"crJ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
 "crK" = (
 /obj/machinery/power/grounding_rod,
 /obj/machinery/camera/emp_proof{
@@ -53624,6 +55695,15 @@
 	network = list("Singularity")
 	},
 /turf/open/floor/plating/airless,
+/area/engine/engineering)
+"crL" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "crM" = (
 /obj/structure/cable{
@@ -53657,6 +55737,28 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"crS" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard)
+"crT" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"crU" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/space,
+/area/space)
 "crV" = (
 /obj/item/wrench,
 /turf/open/floor/plating/airless,
@@ -53683,6 +55785,19 @@
 /obj/structure/transit_tube,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"crZ" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"csa" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "csb" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
@@ -53701,6 +55816,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/space,
 /area/maintenance/aft)
+"csd" = (
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
 "cse" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -53715,6 +55833,18 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"csf" = (
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 8;
+	state = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "csg" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 1;
@@ -53724,6 +55854,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"csh" = (
+/obj/structure/transit_tube{
+	icon_state = "D-SW"
+	},
+/turf/open/space,
+/area/space)
 "csi" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 1
@@ -53757,6 +55893,12 @@
 "cso" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/crossing/horizontal,
+/turf/open/space,
+/area/space)
+"csp" = (
+/obj/structure/transit_tube{
+	icon_state = "E-W-Pass"
+	},
 /turf/open/space,
 /area/space)
 "csq" = (
@@ -53795,6 +55937,11 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/disposal/incinerator)
+"css" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
 "cst" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -53813,9 +55960,21 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"csv" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "csw" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/space,
+/area/space)
+"csx" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
 /area/space)
 "csy" = (
@@ -53837,6 +55996,11 @@
 	state = 2
 	},
 /turf/open/floor/plating/airless,
+/area/space/nearstation)
+"csB" = (
+/obj/item/wirecutters,
+/obj/structure/lattice,
+/turf/open/space,
 /area/space/nearstation)
 "csC" = (
 /obj/effect/turf_decal/stripes/line{
@@ -53867,6 +56031,18 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
+"csG" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "csH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -53879,6 +56055,29 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"csJ" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"csK" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"csL" = (
+/obj/structure/transit_tube{
+	icon_state = "D-NE"
+	},
+/turf/open/space,
+/area/space)
 "csM" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -53894,6 +56093,26 @@
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"csP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4";
+	d1 = 1;
+	d2 = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4;
+	initialize_directions = 11
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "csQ" = (
 /obj/item/wrench,
 /turf/open/floor/plating/airless,
@@ -53904,6 +56123,10 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
+/area/space/nearstation)
+"csS" = (
+/obj/item/weldingtool,
+/turf/open/space,
 /area/space/nearstation)
 "csT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -53992,6 +56215,16 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/space,
 /area/space)
+"cte" = (
+/obj/item/device/radio/off,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"ctf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "ctg" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -54035,12 +56268,30 @@
 	},
 /turf/closed/wall,
 /area/ai_monitored/turret_protected/aisat_interior)
+"ctl" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "ctm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"ctn" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "cto" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Foyer";
@@ -54162,6 +56413,22 @@
 /obj/machinery/power/tracker,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/aft)
+"ctC" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Singularity West";
+	dir = 1;
+	network = list("Singularity")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"ctD" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Singularity East";
+	dir = 1;
+	network = list("Singularity")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "ctE" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/plating,
@@ -54560,6 +56827,19 @@
 	dir = 4
 	},
 /area/ai_monitored/turret_protected/aisat_interior)
+"cut" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "cuu" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -56085,6 +58365,11 @@
 "cxu" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/transport)
+"cxv" = (
+/obj/structure/window/shuttle,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/transport)
 "cxw" = (
 /obj/structure/grille,
 /obj/structure/window/shuttle,
@@ -56112,6 +58397,10 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plating/airless,
+/area/shuttle/transport)
+"cxz" = (
+/obj/machinery/computer/shuttle/ferry/request,
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
 "cxA" = (
 /obj/effect/turf_decal/stripes/line{
@@ -56181,6 +58470,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"cxH" = (
+/obj/structure/closet/crate,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
 "cxI" = (
 /obj/structure/chair{
 	dir = 1
@@ -56771,6 +59064,14 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"czi" = (
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/abandoned)
+"czj" = (
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/abandoned)
 "czk" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 8;
@@ -56803,6 +59104,9 @@
 /obj/structure/light_construct,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
+"czo" = (
+/turf/open/space,
+/area/shuttle/syndicate)
 "czp" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -56810,6 +59114,12 @@
 /obj/structure/shuttle/engine/heater,
 /turf/open/floor/plating/airless,
 /area/shuttle/supply)
+"czq" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 5
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate)
 "czr" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/mineral/titanium,
@@ -56890,6 +59200,9 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"czE" = (
+/turf/open/floor/engine,
+/area/engine/engineering)
 "czF" = (
 /obj/machinery/power/grounding_rod,
 /obj/machinery/camera/emp_proof{
@@ -57048,6 +59361,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"czV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "czW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -57181,7 +59506,8 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "2-4";
+	
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -57211,9 +59537,18 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "2-8";
+	
 	},
 /turf/open/floor/plating/airless,
+/area/space/nearstation)
+"cAo" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
 /area/space/nearstation)
 "cAp" = (
 /obj/structure/cable/yellow{
@@ -57264,11 +59599,26 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"cAu" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 4;
+	icon_state = "emitter";
+	state = 2;
+	
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cAv" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "1-4";
+	
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -57282,7 +59632,8 @@
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "1-8";
+	
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -57290,7 +59641,8 @@
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "1-8";
+	
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -57423,6 +59775,23 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"cAO" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cAP" = (
+/obj/structure/sign/fire,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "cAQ" = (
 /obj/structure/chair,
 /turf/open/floor/plating,
@@ -57689,6 +60058,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"cBs" = (
+/obj/structure/table/optable{
+	name = "Robotics Operating Table"
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/white,
+/area/science/robotics/lab)
 "cBt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -57894,6 +60270,15 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
+"cBQ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cBR" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/space/basic,
@@ -57984,6 +60369,10 @@
 /obj/item/clothing/under/burial,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"cCa" = (
+/obj/item/clothing/head/hardhat,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cCb" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -58108,6 +60497,10 @@
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"cCr" = (
+/obj/machinery/deepfryer,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "cCs" = (
 /obj/structure/mining_shuttle_beacon{
 	dir = 4
@@ -58127,6 +60520,9 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/pod/dark,
 /area/shuttle/transport)
+"cCv" = (
+/turf/open/floor/pod/light,
+/area/space)
 "cCw" = (
 /obj/machinery/door/airlock/titanium,
 /turf/open/floor/pod/light,
@@ -58150,6 +60546,133 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/pod/light,
 /area/shuttle/transport)
+"cCA" = (
+/turf/open/floor/pod/light,
+/area/space)
+"cCB" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10;
+	pixel_x = 0;
+	initialize_directions = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"cCC" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"cCD" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Engine";
+	on = 0
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"cCE" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"cCF" = (
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
+"cCG" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
+/turf/open/space,
+/area/space/nearstation)
+"cCH" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cCI" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cCJ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cCK" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cCL" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cCM" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cCN" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cCO" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cCP" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/turf/open/space,
+/area/space/nearstation)
+"cCQ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
+"cCR" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
+/turf/open/space,
+/area/space/nearstation)
+"cCS" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "cCT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -58159,10 +60682,25 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cCU" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
+"cCV" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
 "cCW" = (
 /obj/machinery/portable_atmospherics/canister/freon,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cCX" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
 "cCY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58173,10 +60711,123 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cCZ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cDa" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cDb" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cDc" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cDd" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
 "cDe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDf" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cDg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDh" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/device/flashlight,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/pipe_dispenser,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDi" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDj" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cDl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -58192,6 +60843,33 @@
 /obj/machinery/vending/engivend,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cDn" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cDo" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDp" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cDq" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -58205,6 +60883,61 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
+/area/engine/engineering)
+"cDr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 4;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDs" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDu" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cDv" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/trinary/filter/flipped{
+	icon_state = "filter_off_f";
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cDw" = (
 /obj/effect/turf_decal/stripes/line,
@@ -58222,12 +60955,95 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cDx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Atmos to Loop";
+	on = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDz" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDA" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
 "cDB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDC" = (
+/obj/item/wrench,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cDD" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	name = "scrubbers pipe";
+	icon_state = "manifold";
+	dir = 4
+	},
+/obj/machinery/meter,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cDE" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "External Gas to Loop"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cDF" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "External Gas to Loop"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cDG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cDH" = (
 /obj/machinery/door/airlock/external{
@@ -58243,6 +61059,117 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cDI" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDL" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cDM" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cDN" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/engine/engineering)
+"cDO" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/engine/engineering)
+"cDP" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/engine/engineering)
+"cDQ" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/engine/engineering)
+"cDR" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cDS" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cDT" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cDU" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cDV" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cDW" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
+"cDX" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
+"cDY" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/space,
+/area/space/nearstation)
 "cDZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58252,11 +61179,111 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cEa" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cEb" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cEc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Port";
+	dir = 4;
+	network = list("SS13","Engine")
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEf" = (
+/obj/machinery/ai_status_display,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"cEg" = (
+/obj/machinery/status_display,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"cEh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Starboard";
+	dir = 8;
+	network = list("SS13","Engine");
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cEj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cEk" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "cEl" = (
 /turf/open/space,
@@ -58283,6 +61310,13 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"cEo" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
 "cEp" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -58292,13 +61326,148 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"cEq" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
 "cEr" = (
 /turf/open/space/basic,
+/area/space/nearstation)
+"cEs" = (
+/turf/open/floor/plating,
 /area/space/nearstation)
 "cEt" = (
 /obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"cEu" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/camera{
+	c_tag = "Supermatter Chamber";
+	dir = 2;
+	network = list("Engine");
+	pixel_x = 23
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
+"cEv" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/supermatter)
+"cEw" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8;
+	on = 1;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
+"cEx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
+"cEy" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	icon_state = "manifold";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/supermatter)
+"cEz" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
+"cEA" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/engine/supermatter)
+"cEB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEC" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Gas";
+	on = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cED" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEE" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/turf/open/space,
+/area/space)
 "cEF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58308,10 +61477,401 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"cEG" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cEH" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cEI" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cEJ" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cEK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cEL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEM" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/item/tank/internals/plasma,
+/turf/open/floor/plating,
+/area/engine/supermatter)
+"cEN" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEO" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cEP" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8;
+	on = 1;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cER" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	icon_state = "manifold";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cES" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cET" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/engine/supermatter)
+"cEU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEV" = (
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cEW" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	icon_state = "connector_map";
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cEX" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cEY" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cEZ" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cFa" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "cFb" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"cFc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4";
+	d1 = 1;
+	d2 = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	icon_state = "pump_map";
+	name = "Cooling Loop Bypass"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFd" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFe" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/engine/supermatter)
+"cFf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8;
+	on = 1;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFh" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engine/supermatter)
+"cFi" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFj" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/engine/supermatter)
+"cFk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix Bypass"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFl" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cFm" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cFn" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space,
+/area/space)
+"cFo" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cFp" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space,
+/area/space)
+"cFq" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cFr" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space,
+/area/space)
+"cFs" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cFt" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space,
+/area/space)
+"cFu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFv" = (
+/obj/machinery/status_display,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cFw" = (
+/obj/structure/sign/electricshock,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"cFx" = (
+/obj/machinery/ai_status_display,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cFy" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFz" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cFA" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cFB" = (
+/turf/closed/wall/r_wall,
+/area/space)
 "cFC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58333,15 +61893,592 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"cFE" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cFF" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cFG" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cFH" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cFI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFJ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFL" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 4;
+	filter_type = "co2";
+	on = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cFM" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"cFN" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 4;
+	filter_type = "o2";
+	on = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Aft";
+	dir = 2;
+	network = list("SS13","Engine");
+	pixel_x = 23
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cFP" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 4;
+	filter_type = "plasma";
+	on = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFR" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 4;
+	filter_type = "";
+	on = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFS" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFT" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8;
+	on = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cFV" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cFW" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cFX" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cFY" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cFZ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cGa" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGb" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cGc" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGd" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGe" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cGf" = (
 /obj/item/crowbar,
 /turf/open/space/basic,
 /area/space/nearstation)
+"cGg" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGh" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGj" = (
+/obj/structure/table,
+/obj/item/pipe_dispenser,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGk" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGl" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGm" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cGn" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGo" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGp" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGq" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cGs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cGt" = (
+/obj/structure/closet/wardrobe/engineering_yellow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGu" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGv" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGw" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGx" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGy" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGz" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGB" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGC" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGD" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGE" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGF" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cGG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cGH" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGI" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Laser Room";
+	req_access_txt = "10"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGJ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Laser Room";
+	req_access_txt = "10"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGK" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGL" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGM" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cGN" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cGO" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGP" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGQ" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGS" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGT" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGU" = (
+/obj/structure/reflector/double{
+	anchored = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGV" = (
+/obj/structure/reflector/box{
+	anchored = 1;
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGW" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGX" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1;
+	on = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGZ" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cHa" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cHb" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHc" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHd" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHe" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHf" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cHg" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cHh" = (
 /obj/machinery/power/tesla_coil,
 /obj/structure/cable/yellow{
@@ -58350,6 +62487,126 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"cHi" = (
+/obj/structure/reflector/box{
+	anchored = 1;
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cHj" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 8;
+	icon_state = "emitter";
+	state = 2
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHk" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cHm" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHn" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHo" = (
+/obj/structure/reflector/single{
+	anchored = 1;
+	dir = 1;
+	icon_state = "reflector"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHp" = (
+/obj/structure/reflector/single{
+	anchored = 1;
+	dir = 4;
+	icon_state = "reflector"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHq" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHr" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHs" = (
+/obj/item/crowbar/large,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHt" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHu" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHv" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHw" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHx" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHy" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHz" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHA" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHB" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHC" = (
+/obj/structure/chair/stool{
+	desc = "Apply butt, tactically.";
+	name = "tactical stool";
+	pixel_y = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate)
 "cHD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58627,6 +62884,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"cHY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/science/robotics/lab)
 "cHZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -58691,6 +62957,27 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
 "cIh" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 1;
+	name = "Port Docking Bay 1"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
+"cIi" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 1;
+	name = "Port Docking Bay 1"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
+"cIj" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 1;
+	name = "Port Docking Bay 1"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
+"cIk" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 1;
 	name = "Port Docking Bay 1"
@@ -58787,6 +63074,9 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/syndicate)
+"cIw" = (
+/turf/open/floor/plasteel/black,
+/area/shuttle/syndicate)
 "cIx" = (
 /obj/structure/chair/office/dark{
 	dir = 4;
@@ -58808,6 +63098,24 @@
 	},
 /area/shuttle/syndicate)
 "cIz" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
+"cIA" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
+"cIB" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
+"cIC" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
+"cID" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
+"cIE" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
+"cIF" = (
 /turf/open/floor/plasteel/vault,
 /area/shuttle/syndicate)
 "cIG" = (
@@ -58857,6 +63165,9 @@
 	dir = 5
 	},
 /area/shuttle/syndicate)
+"cIM" = (
+/turf/open/floor/plasteel/black,
+/area/shuttle/syndicate)
 "cIN" = (
 /obj/structure/chair{
 	dir = 8;
@@ -58879,6 +63190,9 @@
 	dir = 5
 	},
 /area/shuttle/syndicate)
+"cIP" = (
+/turf/open/floor/plasteel/black,
+/area/shuttle/syndicate)
 "cIQ" = (
 /obj/structure/chair{
 	dir = 8;
@@ -58897,10 +63211,41 @@
 	dir = 5
 	},
 /area/shuttle/syndicate)
+"cIS" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cIT" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
 "cIU" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/vault{
 	dir = 8
+	},
+/area/shuttle/syndicate)
+"cIV" = (
+/obj/structure/chair{
+	dir = 4;
+	name = "tactical chair"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cIW" = (
+/turf/open/floor/plasteel/black,
+/area/shuttle/syndicate)
+"cIX" = (
+/obj/structure/chair{
+	dir = 8;
+	name = "tactical chair"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
 /area/shuttle/syndicate)
 "cIY" = (
@@ -58911,10 +63256,43 @@
 	dir = 4
 	},
 /area/shuttle/syndicate)
+"cIZ" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cJa" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
 "cJb" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel/vault{
 	dir = 8
+	},
+/area/shuttle/syndicate)
+"cJc" = (
+/obj/structure/chair{
+	dir = 4;
+	name = "tactical chair"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cJd" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cJe" = (
+/obj/structure/chair{
+	dir = 8;
+	name = "tactical chair"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
 /area/shuttle/syndicate)
 "cJf" = (
@@ -58955,6 +63333,24 @@
 	tag = "icon-podhatch (NORTH)";
 	icon_state = "podhatch";
 	dir = 1
+	},
+/area/shuttle/syndicate)
+"cJg" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (EAST)";
+	icon_state = "podhatch";
+	dir = 4
+	},
+/area/shuttle/syndicate)
+"cJh" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cJi" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
 /area/shuttle/syndicate)
 "cJj" = (
@@ -59000,6 +63396,24 @@
 	dir = 6
 	},
 /area/shuttle/syndicate)
+"cJo" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (EAST)";
+	icon_state = "podhatch";
+	dir = 4
+	},
+/area/shuttle/syndicate)
+"cJp" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cJq" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
 "cJr" = (
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -59014,6 +63428,36 @@
 	dir = 8
 	},
 /area/shuttle/syndicate)
+"cJt" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cJu" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cJv" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cJw" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cJx" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cJy" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
 "cJz" = (
 /obj/machinery/suit_storage_unit/syndicate,
 /turf/open/floor/plasteel/podhatch{
@@ -59022,13 +63466,45 @@
 	dir = 6
 	},
 /area/shuttle/syndicate)
+"cJA" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cJB" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
 "cJC" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/shuttle/syndicate)
+"cJD" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cJE" = (
+/turf/open/floor/plasteel/black,
+/area/shuttle/syndicate)
+"cJF" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
 "cJG" = (
+/obj/structure/chair{
+	dir = 1;
+	name = "tactical chair"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate)
+"cJH" = (
 /obj/structure/chair{
 	dir = 1;
 	name = "tactical chair"
@@ -59049,10 +63525,32 @@
 /obj/machinery/ai_status_display,
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate)
+"cJK" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cJL" = (
+/turf/open/floor/plasteel/black,
+/area/shuttle/syndicate)
+"cJM" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cJN" = (
+/obj/machinery/status_display,
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate)
 "cJO" = (
 /obj/machinery/sleeper/syndie{
 	dir = 4
 	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate)
+"cJP" = (
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -59109,6 +63607,19 @@
 /obj/item/stack/medical/ointment,
 /turf/open/floor/plasteel/vault{
 	dir = 8
+	},
+/area/shuttle/syndicate)
+"cJT" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cJU" = (
+/turf/open/floor/plasteel/black,
+/area/shuttle/syndicate)
+"cJV" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
 /area/shuttle/syndicate)
 "cJW" = (
@@ -59178,6 +63689,18 @@
 	dir = 8
 	},
 /area/shuttle/syndicate)
+"cKc" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
+"cKd" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
+"cKe" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
+"cKf" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
 "cKg" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -59187,10 +63710,41 @@
 	dir = 5
 	},
 /area/shuttle/syndicate)
+"cKh" = (
+/turf/open/floor/plasteel/black,
+/area/shuttle/syndicate)
 "cKi" = (
 /obj/machinery/light{
 	dir = 4
 	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cKj" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
+"cKk" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
+"cKl" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
+"cKm" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
+"cKn" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
+"cKo" = (
+/obj/machinery/sleeper/syndie{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate)
+"cKp" = (
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -59207,6 +63761,13 @@
 	dir = 1
 	},
 /area/shuttle/syndicate)
+"cKs" = (
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (NORTH)";
+	icon_state = "podhatch";
+	dir = 1
+	},
+/area/shuttle/syndicate)
 "cKt" = (
 /obj/machinery/door/airlock/hatch{
 	req_access_txt = "150"
@@ -59215,8 +63776,56 @@
 	dir = 8
 	},
 /area/shuttle/syndicate)
+"cKu" = (
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (NORTH)";
+	icon_state = "podhatch";
+	dir = 1
+	},
+/area/shuttle/syndicate)
+"cKv" = (
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (NORTH)";
+	icon_state = "podhatch";
+	dir = 1
+	},
+/area/shuttle/syndicate)
+"cKw" = (
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (NORTH)";
+	icon_state = "podhatch";
+	dir = 1
+	},
+/area/shuttle/syndicate)
+"cKx" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate)
+"cKy" = (
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (NORTH)";
+	icon_state = "podhatch";
+	dir = 1
+	},
+/area/shuttle/syndicate)
+"cKz" = (
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (NORTH)";
+	icon_state = "podhatch";
+	dir = 1
+	},
+/area/shuttle/syndicate)
 "cKA" = (
 /turf/open/floor/plasteel/podhatch{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cKB" = (
+/turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/shuttle/syndicate)
@@ -59235,16 +63844,47 @@
 	dir = 8
 	},
 /area/shuttle/syndicate)
+"cKE" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
 "cKF" = (
 /turf/open/floor/plasteel/podhatch{
 	dir = 10
 	},
+/area/shuttle/syndicate)
+"cKG" = (
+/turf/open/floor/plasteel/podhatch,
+/area/shuttle/syndicate)
+"cKH" = (
+/turf/open/floor/plasteel/podhatch,
+/area/shuttle/syndicate)
+"cKI" = (
+/turf/open/floor/plasteel/podhatch,
+/area/shuttle/syndicate)
+"cKJ" = (
+/turf/open/floor/plasteel/podhatch,
+/area/shuttle/syndicate)
+"cKK" = (
+/turf/open/floor/plasteel/podhatch,
+/area/shuttle/syndicate)
+"cKL" = (
+/turf/open/floor/plasteel/podhatch,
+/area/shuttle/syndicate)
+"cKM" = (
+/turf/open/floor/plasteel/podhatch,
 /area/shuttle/syndicate)
 "cKN" = (
 /turf/open/floor/plasteel/podhatch{
 	tag = "icon-podhatch (SOUTHEAST)";
 	icon_state = "podhatch";
 	dir = 6
+	},
+/area/shuttle/syndicate)
+"cKO" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
 /area/shuttle/syndicate)
 "cKP" = (
@@ -59305,6 +63945,15 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/vault,
 /area/shuttle/syndicate)
+"cKV" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
+"cKW" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
+"cKX" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
 "cKY" = (
 /obj/item/device/sbeacondrop/bomb{
 	pixel_y = 5
@@ -59336,6 +63985,12 @@
 	dir = 8
 	},
 /area/shuttle/syndicate)
+"cLa" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate)
 "cLb" = (
 /obj/machinery/door/window{
 	dir = 1;
@@ -59364,6 +64019,11 @@
 	dir = 8
 	},
 /area/shuttle/syndicate)
+"cLe" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
 "cLf" = (
 /obj/structure/sink{
 	dir = 4;
@@ -59386,6 +64046,24 @@
 	req_access_txt = "0"
 	},
 /turf/open/floor/circuit/red,
+/area/shuttle/syndicate)
+"cLh" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cLi" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate)
+"cLj" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/shuttle/syndicate)
 "cLk" = (
 /obj/item/cautery,
@@ -59418,6 +64096,22 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/shuttle/syndicate)
+"cLo" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate)
+"cLp" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate)
 "cLq" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/circuit/red,
@@ -59427,6 +64121,34 @@
 	intercept = 1
 	},
 /turf/open/floor/circuit/red,
+/area/shuttle/syndicate)
+"cLs" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/circuit/red,
+/area/shuttle/syndicate)
+"cLt" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate)
+"cLu" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate)
+"cLv" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
 /area/shuttle/syndicate)
 "cLw" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -59441,6 +64163,68 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/syndicate)
 "cLy" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion_r"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate)
+"cLz" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate)
+"cLA" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate)
+"cLB" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate)
+"cLC" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion_l"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate)
+"cLD" = (
+/obj/structure/shuttle/engine/propulsion,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate)
+"cLE" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion_r"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate)
+"cLF" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion_l"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate)
+"cLG" = (
+/obj/structure/shuttle/engine/propulsion,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate)
+"cLH" = (
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion_r"
 	},
@@ -59589,9 +64373,23 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
+"cMg" = (
+/obj/structure/light_construct,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/abandoned)
 "cMh" = (
 /obj/structure/light_construct/small{
 	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/abandoned)
+"cMi" = (
+/obj/structure/light_construct,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/abandoned)
+"cMj" = (
+/obj/structure/light_construct{
+	dir = 1
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
@@ -59608,6 +64406,88 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/labor)
+"cMm" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cMn" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cMo" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cMp" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cMq" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cMr" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cMs" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cMt" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cMu" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cMv" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cMw" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cMx" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cMy" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cMz" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cMA" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cMB" = (
 /obj/structure/window/shuttle,
 /obj/structure/grille,
@@ -59634,6 +64514,15 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cME" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"cMF" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"cMG" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "cMH" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -59643,7 +64532,146 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cMI" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
+"cMJ" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
+"cMK" = (
+/turf/open/floor/engine,
+/area/engine/supermatter)
+"cML" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"cMM" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"cMN" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/supermatter)
+"cMO" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"cMP" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "cMQ" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cMR" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cMS" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cMT" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cMU" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cMV" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cMW" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cMX" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cMY" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cMZ" = (
 /obj/structure/cable{
 	icon_state = "0-2";
 	d2 = 2
@@ -59662,13 +64690,281 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/aft)
+"cNb" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNc" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNd" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNe" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNf" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNg" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNh" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNi" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNj" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNk" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNl" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNm" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNn" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNo" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNp" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNq" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNr" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNs" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNt" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNu" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNv" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNw" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNx" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNy" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNz" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNA" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNB" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cNC" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
+"cND" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
 "cNE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"cNF" = (
+/turf/closed/wall,
+/area/quartermaster/sorting)
 "cNG" = (
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"cNH" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "cNI" = (
@@ -59677,6 +64973,12 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "cNJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"cNK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -59719,6 +65021,28 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"cNO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"cNP" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
+"cNQ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
 /area/quartermaster/sorting)
 "cNR" = (
 /obj/structure/cable{
@@ -59813,12 +65137,102 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cOa" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cOb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cOc" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOd" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
 "cOe" = (
 /turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOf" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOh" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOi" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOj" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOk" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOl" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOm" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOn" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOo" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOp" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOq" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOs" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOt" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOu" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOv" = (
+/turf/closed/wall,
 /area/maintenance/starboard/aft)
 "cOw" = (
 /obj/structure/grille,
@@ -59830,7 +65244,94 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cOy" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOz" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOA" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOB" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOC" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOD" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOE" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOF" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOG" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOH" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOI" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOJ" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOK" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOL" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOM" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cON" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOO" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOP" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOQ" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOR" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOS" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cOT" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOU" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOV" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOW" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOX" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cOY" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cOZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -59840,10 +65341,110 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cPb" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPc" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPd" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPe" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cPf" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPh" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPi" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPj" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cPk" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPm" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPn" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cPo" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cPp" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cPq" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cPr" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPs" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cPt" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cPu" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPv" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPw" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPy" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPz" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cPA" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4
 	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cPB" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPC" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPD" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cPE" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cPF" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cPG" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cPH" = (
@@ -59860,10 +65461,158 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cPJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPK" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPL" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPM" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPN" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPO" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cPP" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPQ" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cPR" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPS" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPT" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPU" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPV" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPW" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPX" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPY" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cPZ" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQa" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQb" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQc" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQd" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQe" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQf" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cQg" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQi" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQj" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQk" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cQl" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cQm" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQn" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQo" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cQp" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cQq" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQr" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQs" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cQt" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cQu" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cQv" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
 "cQw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQx" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQy" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cQz" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
 "cQB" = (
@@ -59881,7 +65630,457 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cQC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cQD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cQE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cQF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cQG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cQH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cQI" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQJ" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQK" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQL" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cQM" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cQN" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQO" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQQ" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQR" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQS" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQT" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQU" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQV" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQW" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQX" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cQY" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cQZ" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRa" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRb" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRc" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRd" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRe" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRf" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRg" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRh" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRi" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRj" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRk" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRl" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRm" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRn" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRo" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRp" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRq" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRr" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRs" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRt" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRu" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRv" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRw" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRx" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRy" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRz" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRA" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRB" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRC" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRG" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRH" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRI" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRJ" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRK" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRL" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRM" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRN" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRO" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRP" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRQ" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRR" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRS" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRT" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRU" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRV" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRW" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cRX" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRY" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cRZ" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cSa" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cSb" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cSc" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cSd" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cSe" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cSf" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cSg" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cSh" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cSi" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cSj" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cSk" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cSl" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cSm" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cSn" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cSo" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cSp" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cSq" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cSr" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cSs" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cSt" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cSu" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cSv" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cSw" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cSx" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"cSy" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"cSz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/chapel/main)
 "cSA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/security/courtroom)
+"cSB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/security/courtroom)
+"cSC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/security/courtroom)
+"cSD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -59926,6 +66125,42 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/security/brig)
+"cSI" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/security/brig)
+"cSJ" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/security/brig)
 "cSK" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
@@ -59940,6 +66175,14 @@
 	},
 /area/hallway/primary/fore)
 "cSM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/hallway/primary/fore)
+"cSN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -59974,7 +66217,45 @@
 	dir = 1
 	},
 /area/hallway/primary/fore)
+"cSR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/hallway/primary/fore)
+"cSS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/hallway/primary/fore)
+"cST" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/hallway/primary/fore)
+"cSU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/hallway/primary/fore)
 "cSV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"cSW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -60001,6 +66282,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"cTa" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "cTb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -60011,6 +66296,14 @@
 	},
 /area/hallway/primary/fore)
 "cTc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 8
+	},
+/area/hallway/primary/fore)
+"cTd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -60053,6 +66346,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hippie/pool)
+"cTi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/plasteel/yellowsiding,
+/area/hippie/pool)
 "cTj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -60083,7 +66385,15 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plasteel/cafeteria,
 /area/hippie/mime)
+"cTm" = (
+/turf/closed/wall,
+/area/hippie/clown)
 "cTn" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel/redyellow,
+/area/hippie/clown)
+"cTo" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plasteel/redyellow,
@@ -60197,6 +66507,9 @@
 "cTE" = (
 /turf/closed/wall,
 /area/hippie/mime)
+"cTF" = (
+/turf/closed/wall,
+/area/hippie/mime)
 "cTG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -60256,7 +66569,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cTL" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cTM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cTN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -60296,6 +66626,15 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cTR" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cTS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -60307,8 +66646,36 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cTT" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cTU" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cTV" = (
 /obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cTW" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cTX" = (
@@ -60345,6 +66712,26 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"cUb" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cUc" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"cUd" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cUe" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -60352,6 +66739,14 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
+/area/space/nearstation)
+"cUf" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
 /area/space/nearstation)
 "cUg" = (
 /obj/machinery/power/emitter{
@@ -60366,6 +66761,22 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"cUh" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cUi" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
 "cUj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -60383,17 +66794,50 @@
 /obj/item/weldingtool,
 /turf/open/space/basic,
 /area/space/nearstation)
+"cUl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
 "cUm" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
+/area/space/nearstation)
+"cUn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
 /area/space/nearstation)
 "cUo" = (
 /obj/item/device/radio,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"cUp" = (
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 8;
+	icon_state = "emitter";
+	state = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cUq" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cUr" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUs" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cUt" = (
 /obj/machinery/camera/emp_proof{
@@ -60403,6 +66847,64 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"cUu" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"cUv" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"cUw" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cUx" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"cUy" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cUz" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Singularity South-East";
@@ -60411,12 +66913,130 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"cUA" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUB" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cUC" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUD" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUE" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "cUF" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"cUG" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cUH" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUI" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUJ" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUK" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUL" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUM" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUN" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUO" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUP" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUQ" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUR" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUS" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUT" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUU" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUV" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cUW" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cUX" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cUY" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cUZ" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cVa" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cVb" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"cVc" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "cVd" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVe" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVf" = (
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cVg" = (
@@ -60425,6 +67045,106 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"cVh" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVi" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVj" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVk" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVl" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVm" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVn" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVo" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVp" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVq" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVr" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVs" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVt" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVu" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVv" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVw" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVy" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVz" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVA" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVB" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVC" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVD" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVE" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVF" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cVG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Pool";
+	c_tag_order = 999;
+	dir = 1
+	},
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 1
+	},
+/area/hippie/pool)
 "cVH" = (
 /mob/living/simple_animal/pet/penguin/baby{
 	name = "Newspaper"
@@ -60441,6 +67161,21 @@
 "cVJ" = (
 /turf/open/floor/plasteel/bar,
 /area/maintenance/port/aft)
+"cVK" = (
+/turf/open/floor/plasteel/bar,
+/area/maintenance/port/aft)
+"cVL" = (
+/turf/open/floor/plasteel/bar,
+/area/maintenance/port/aft)
+"cVM" = (
+/turf/open/floor/plasteel/bar,
+/area/maintenance/port/aft)
+"cVN" = (
+/turf/open/floor/plasteel/bar,
+/area/maintenance/port/aft)
+"cVO" = (
+/turf/open/floor/plasteel/bar,
+/area/maintenance/port/aft)
 "cVP" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -60449,6 +67184,14 @@
 "cVQ" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
+/turf/open/floor/plasteel/bar,
+/area/maintenance/port/aft)
+"cVR" = (
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/bar,
+/area/maintenance/port/aft)
+"cVS" = (
+/obj/structure/table/wood,
 /turf/open/floor/plasteel/bar,
 /area/maintenance/port/aft)
 "cVT" = (
@@ -60460,6 +67203,16 @@
 /turf/open/floor/carpet/black,
 /area/maintenance/port/aft)
 "cVV" = (
+/turf/open/floor/carpet/black,
+/area/maintenance/port/aft)
+"cVW" = (
+/turf/open/floor/carpet/black,
+/area/maintenance/port/aft)
+"cVX" = (
+/obj/structure/chair/stool,
+/turf/open/floor/carpet/black,
+/area/maintenance/port/aft)
+"cVY" = (
 /turf/open/floor/carpet/black,
 /area/maintenance/port/aft)
 "cVZ" = (
@@ -60532,6 +67285,12 @@
 /obj/machinery/icecream_vat,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"cWn" = (
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cWo" = (
 /obj/structure/statue/sandstone/assistant{
 	anchored = 1;
@@ -60554,6 +67313,11 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"cWs" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "cWt" = (
 /obj/machinery/clonepod,
 /turf/open/floor/plasteel/white,
@@ -60594,10 +67358,91 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"cWz" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cWA" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cWB" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cWC" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cWD" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cWE" = (
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space)
+"cWF" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"cWG" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"cWH" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"cWI" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"cWJ" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"cWK" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"cWL" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"cWM" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"cWN" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"cWO" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"cWP" = (
+/turf/closed/wall,
+/area/maintenance/commiespy)
+"cWQ" = (
+/turf/closed/wall,
+/area/maintenance/commiespy)
+"cWR" = (
+/turf/closed/wall,
+/area/maintenance/commiespy)
+"cWS" = (
+/turf/closed/wall,
+/area/maintenance/commiespy)
+"cWT" = (
+/turf/closed/wall,
+/area/maintenance/commiespy)
+"cWU" = (
+/turf/closed/wall,
+/area/maintenance/commiespy)
+"cWV" = (
+/turf/closed/wall,
+/area/maintenance/commiespy)
 "cWW" = (
 /obj/structure/table,
 /obj/item/device/flashlight/lamp,
@@ -60675,16 +67520,26 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/maintenance/commiespy)
+"cXa" = (
+/turf/closed/wall,
+/area/maintenance/commiespy)
 "cXb" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space,
 /area/space)
+"cXc" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
 "cXd" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating/airless,
 /area/maintenance/starboard/fore)
+"cXe" = (
+/turf/closed/wall,
+/area/maintenance/commiespy)
 "cXf" = (
 /obj/structure/table,
 /obj/item/storage/photo_album{
@@ -60724,6 +67579,9 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/maintenance/commiespy)
+"cXj" = (
+/turf/closed/wall,
+/area/maintenance/commiespy)
 "cXk" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 2;
@@ -60731,6 +67589,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"cXl" = (
+/turf/closed/wall,
+/area/maintenance/commiespy)
 "cXm" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -60761,6 +67622,9 @@
 /obj/item/clothing/neck/stethoscope,
 /turf/open/floor/plasteel/black,
 /area/maintenance/commiespy)
+"cXo" = (
+/turf/open/floor/plasteel/black,
+/area/maintenance/commiespy)
 "cXp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -60770,11 +67634,20 @@
 /obj/machinery/modular_computer/console/preset/command,
 /turf/open/floor/plasteel/black,
 /area/maintenance/commiespy)
+"cXq" = (
+/turf/closed/wall,
+/area/maintenance/commiespy)
 "cXr" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "cXs" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/starboard/fore)
+"cXt" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/starboard/fore)
+"cXu" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/starboard/fore)
 "cXv" = (
@@ -60783,6 +67656,9 @@
 /area/maintenance/starboard/fore)
 "cXw" = (
 /obj/structure/barricade/wooden,
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/starboard/fore)
+"cXx" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/starboard/fore)
 "cXy" = (
@@ -60803,6 +67679,9 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/wood,
 /area/maintenance/starboard/fore)
+"cXC" = (
+/turf/closed/wall,
+/area/maintenance/commiespy)
 "cXD" = (
 /obj/machinery/vending/sustenance,
 /obj/item/device/radio/intercom{
@@ -60815,6 +67694,12 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/maintenance/commiespy)
+"cXE" = (
+/turf/open/floor/plasteel/black,
+/area/maintenance/commiespy)
+"cXF" = (
+/turf/open/floor/plasteel/black,
+/area/maintenance/commiespy)
 "cXG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -60824,8 +67709,21 @@
 /obj/machinery/computer/crew,
 /turf/open/floor/plasteel/black,
 /area/maintenance/commiespy)
+"cXH" = (
+/turf/closed/wall,
+/area/maintenance/commiespy)
+"cXI" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/starboard/fore)
 "cXJ" = (
 /obj/item/gun/ballistic/automatic/toy/pistol,
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/starboard/fore)
+"cXK" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/starboard/fore)
+"cXL" = (
+/obj/item/projectile/bullet/reusable/foam_dart,
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/starboard/fore)
 "cXM" = (
@@ -60834,6 +67732,12 @@
 	dir = 8
 	},
 /obj/item/gun/ballistic/shotgun/toy/crossbow,
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/starboard/fore)
+"cXN" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/starboard/fore)
+"cXO" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/starboard/fore)
 "cXP" = (
@@ -60847,6 +67751,12 @@
 "cXR" = (
 /turf/open/floor/wood,
 /area/maintenance/starboard/fore)
+"cXS" = (
+/turf/open/floor/wood,
+/area/maintenance/starboard/fore)
+"cXT" = (
+/turf/open/floor/wood,
+/area/maintenance/starboard/fore)
 "cXU" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 1;
@@ -60854,6 +67764,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"cXV" = (
+/turf/closed/wall,
+/area/maintenance/commiespy)
 "cXW" = (
 /obj/machinery/vending/sovietsoda,
 /turf/open/floor/plasteel/black,
@@ -60886,6 +67799,16 @@
 /obj/item/ammo_casing/caseless/foam_dart,
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/starboard/fore)
+"cYb" = (
+/obj/item/projectile/bullet/reusable/foam_dart,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"cYc" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/starboard/fore)
+"cYd" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/starboard/fore)
 "cYe" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -60894,10 +67817,30 @@
 /obj/item/ammo_box/foambox,
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/starboard/fore)
+"cYf" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/starboard/fore)
+"cYg" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/starboard/fore)
 "cYh" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
+/area/maintenance/starboard/fore)
+"cYi" = (
+/turf/open/floor/wood,
+/area/maintenance/starboard/fore)
+"cYj" = (
+/turf/open/floor/wood,
+/area/maintenance/starboard/fore)
+"cYk" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/maintenance/starboard/fore)
+"cYl" = (
+/turf/open/floor/wood,
 /area/maintenance/starboard/fore)
 "cYm" = (
 /obj/machinery/door/airlock/maintenance{
@@ -60914,12 +67857,25 @@
 /obj/item/ammo_box/foambox,
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/starboard/fore)
+"cYo" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/starboard/fore)
+"cYp" = (
+/obj/item/projectile/bullet/reusable/foam_dart,
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/starboard/fore)
 "cYq" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/starboard/fore)
+"cYr" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/starboard/fore)
+"cYs" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/starboard/fore)
 "cYt" = (
@@ -60940,6 +67896,15 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/starboard/fore)
+"cYv" = (
+/turf/open/floor/wood,
+/area/maintenance/starboard/fore)
+"cYw" = (
+/turf/open/floor/wood,
+/area/maintenance/starboard/fore)
+"cYx" = (
+/turf/open/floor/wood,
+/area/maintenance/starboard/fore)
 "cYy" = (
 /obj/structure/closet/wardrobe/yellow,
 /turf/open/floor/wood,
@@ -60953,6 +67918,33 @@
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
 "cYA" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"cYB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"cYC" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"cYD" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -60986,6 +67978,23 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/starboard/fore)
+"cYH" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/maintenance/starboard/fore)
+"cYI" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/maintenance/starboard/fore)
+"cYJ" = (
+/turf/open/floor/wood,
+/area/maintenance/starboard/fore)
+"cYK" = (
+/turf/open/floor/wood,
+/area/maintenance/starboard/fore)
 "cYL" = (
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/wood,
@@ -60998,17 +68007,45 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
+"cYN" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"cYO" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "cYP" = (
 /obj/machinery/light/small,
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/starboard/fore)
+"cYQ" = (
+/turf/open/floor/wood,
+/area/maintenance/starboard/fore)
+"cYR" = (
+/turf/open/floor/wood,
+/area/maintenance/starboard/fore)
+"cYS" = (
+/turf/open/floor/wood,
+/area/maintenance/starboard/fore)
+"cYT" = (
+/turf/open/floor/wood,
+/area/maintenance/starboard/fore)
 "cYU" = (
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
+/area/maintenance/starboard/fore)
+"cYV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/closed/wall,
 /area/maintenance/starboard/fore)
 "cYW" = (
 /obj/item/ammo_box/foambox,
@@ -61038,11 +68075,42 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
+"cZa" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
+"cZb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "cZc" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
+"cZd" = (
+/obj/structure/table,
+/obj/item/gun/ballistic/automatic/toy/pistol,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"cZe" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
@@ -61060,6 +68128,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/hippie/pool)
+"cZg" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "cZh" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet/crate,
@@ -61090,6 +68166,14 @@
 /obj/structure/closet/athletic_mixed,
 /turf/open/floor/plasteel,
 /area/hippie/pool)
+"cZl" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "cZm" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -61132,6 +68216,21 @@
 "cZr" = (
 /turf/open/floor/plasteel,
 /area/hippie/pool)
+"cZs" = (
+/turf/open/floor/plasteel,
+/area/hippie/pool)
+"cZt" = (
+/turf/open/floor/plasteel,
+/area/hippie/pool)
+"cZu" = (
+/turf/open/floor/plasteel,
+/area/hippie/pool)
+"cZv" = (
+/turf/open/floor/plasteel,
+/area/hippie/pool)
+"cZw" = (
+/turf/open/floor/plasteel,
+/area/hippie/pool)
 "cZx" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -61148,6 +68247,12 @@
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 4
 	},
+/area/hippie/pool)
+"cZy" = (
+/turf/open/floor/plasteel,
+/area/hippie/pool)
+"cZz" = (
+/turf/open/floor/plasteel,
 /area/hippie/pool)
 "cZA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -61203,6 +68308,9 @@
 "cZI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light,
+/turf/open/floor/plasteel/neutral/side,
+/area/hippie/pool)
+"cZJ" = (
 /turf/open/floor/plasteel/neutral/side,
 /area/hippie/pool)
 "cZK" = (
@@ -61375,7 +68483,18 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
+"dae" = (
+/obj/structure/closet/coffin,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/chapel/main)
 "daf" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/chapel{
+	dir = 1
+	},
+/area/chapel/main)
+"dag" = (
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -61456,12 +68575,27 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
+"dat" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/chapel/main)
 "dau" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
 	on = 1;
 	scrub_Toxins = 0
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/chapel/main)
+"dav" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -61480,6 +68614,12 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/chapel/main)
+"day" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
@@ -61549,6 +68689,10 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
+"daL" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/black,
+/area/chapel/main)
 "daM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
@@ -61609,6 +68753,10 @@
 	},
 /area/hallway/secondary/exit)
 "daS" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"daT" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -61729,6 +68877,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"dbn" = (
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
+"dbo" = (
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
+"dbp" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
+"dbq" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "dbr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -61750,6 +68917,28 @@
 /mob/living/simple_animal/cow,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
+"dbu" = (
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
+"dbv" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
+"dbw" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"dbx" = (
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
+"dby" = (
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "dbz" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -61757,6 +68946,12 @@
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
+/area/hallway/secondary/exit)
+"dbA" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "dbB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -61777,6 +68972,12 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
+"dbE" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "dbF" = (
 /obj/machinery/camera{
 	c_tag = "Escape Hallway South";
@@ -61791,6 +68992,10 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"dbH" = (
+/obj/item/ammo_casing/caseless/foam_dart,
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/starboard/fore)
 "dbI" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -61818,11 +69023,27 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"dbN" = (
+/turf/open/floor/plasteel/vault,
+/area/science/misc_lab)
 "dbO" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/closet/l3closet/scientist,
+/turf/open/floor/plasteel/vault,
+/area/science/misc_lab)
+"dbP" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/engine,
+/area/science/misc_lab)
+"dbQ" = (
+/turf/open/floor/plasteel/vault,
+/area/science/misc_lab)
+"dbR" = (
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
 "dbS" = (
@@ -61855,7 +69076,22 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
+"dbX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel/vault,
+/area/science/misc_lab)
 "dbY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel/vault,
+/area/science/misc_lab)
+"dbZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -61885,6 +69121,12 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/misc_lab)
+"dce" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
@@ -61921,12 +69163,23 @@
 /obj/item/stack/sheet/mineral/plasma,
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
+"dcj" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/misc_lab)
 "dck" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/science{
 	name = "Lab Storage"
 	},
 /turf/open/floor/plasteel/vault,
+/area/science/misc_lab)
+"dcl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
 /area/science/misc_lab)
 "dcm" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -62034,70 +69287,7 @@
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"dxG" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/structure/reagent_dispensers/chemical,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"elp" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"eLM" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"fiD" = (
-/obj/effect/landmark/start/bartender,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"fnE" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"ftJ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/chem_dispenser/drinks/beer,
-/obj/item/device/radio/intercom{
-	pixel_y = 25
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"jrh" = (
-/obj/structure/disposalpipe/segment,
-/mob/living/carbon/monkey/punpun,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"kxC" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"lfB" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"pms" = (
+"dcB" = (
 /obj/machinery/door/window/eastleft{
 	dir = 8;
 	icon_state = "right";
@@ -62109,14 +69299,20 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"sKc" = (
+"dcC" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/spacecash/c100,
-/obj/item/stack/spacecash/c100,
-/obj/item/stack/spacecash/c100,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"uMd" = (
+"dcD" = (
+/obj/structure/disposalpipe/segment{
+	base_icon_state = null;
+	dir = 1;
+	dpdir = 0;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"dcE" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -62130,89 +69326,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"AoF" = (
+"dcF" = (
 /obj/structure/table/reinforced,
-/obj/item/lighter,
-/obj/machinery/camera{
-	c_tag = "Bar";
-	dir = 2;
-	network = list("SS13")
-	},
+/obj/item/stack/spacecash/c100,
+/obj/item/stack/spacecash/c100,
+/obj/item/stack/spacecash/c100,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"Bii" = (
-/obj/machinery/door/window/southright{
-	name = "Bar Door";
-	req_access_txt = "0";
-	req_one_access_txt = "25;28"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"HzI" = (
+"dcG" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/shaker,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"MTE" = (
-/obj/structure/disposalpipe/segment{
-	base_icon_state = null;
-	dir = 1;
-	dpdir = 0;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"NnN" = (
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/table/reinforced,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"Prn" = (
-/obj/structure/table/wood,
-/obj/item/gun/ballistic/revolver/doublebarrel{
-	desc = "The barkeeper's trusty double-barrel. Works beautifully, despite its age.";
-	name = "Ol' Faithful"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"RCR" = (
-/obj/structure/sign/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
-	pixel_x = -28;
-	pixel_y = -4
-	},
-/obj/machinery/button/door{
-	id = "barShutters";
-	name = "bar shutters";
-	pixel_x = 4;
-	pixel_y = 28
-	},
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"Tar" = (
-/obj/structure/closet/secure_closet/bar,
-/obj/item/book/manual/barman_recipes,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"Unp" = (
-/obj/structure/closet/gmcloset,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/cable_coil,
-/obj/item/device/flashlight/lamp,
-/obj/item/device/flashlight/lamp/green,
-/obj/item/screwdriver,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"UZd" = (
-/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/rag,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 
@@ -76471,13 +83594,13 @@ aNf
 aLA
 aQD
 aSd
-aTq
-aTq
-aTq
-aTq
+cTm
+cTm
+cTm
+cTm
 cTu
 baJ
-aTq
+cTm
 cTI
 beO
 beU
@@ -76734,7 +83857,7 @@ cWp
 aWs
 cTv
 cTA
-aTq
+cTm
 bbf
 beT
 beT
@@ -77248,7 +84371,7 @@ cTr
 aXN
 aUO
 cTB
-aTq
+cTm
 bcI
 aPz
 bdt
@@ -77499,13 +84622,13 @@ ayl
 ayl
 ayl
 aSf
-aTq
-aTq
-aTq
-aTq
-aTq
-aTq
-aTq
+cTm
+cTm
+cTm
+cTm
+cTm
+cTm
+cTm
 aPz
 aPz
 bdB
@@ -81135,8 +88258,8 @@ aaa
 aaa
 bCq
 cVJ
-bRd
-bSn
+cVR
+cVX
 bCq
 aoV
 cbj
@@ -81392,8 +88515,8 @@ aaa
 aaa
 bLv
 cVJ
-bRd
-bSn
+cVR
+cVX
 bCq
 bCq
 cbj
@@ -81649,8 +88772,8 @@ akD
 aaa
 bCq
 cVJ
-bRd
-bSn
+cVR
+cVX
 cVV
 bCq
 cbk
@@ -81906,8 +89029,8 @@ akD
 aaa
 bLv
 bPR
-bRd
-bSn
+cVR
+cVX
 cVZ
 bCq
 bVy
@@ -82164,7 +89287,7 @@ aaa
 bCq
 cVJ
 bRf
-bSn
+cVX
 bTu
 bCq
 bVB
@@ -82421,7 +89544,7 @@ aaa
 bLv
 cVJ
 bRe
-bSn
+cVX
 bTt
 bCq
 bVA
@@ -84447,7 +91570,7 @@ apd
 bbU
 cCk
 apd
-aZK
+cNF
 bgB
 bhX
 bgv
@@ -84707,7 +91830,7 @@ apd
 bfj
 bgC
 bia
-aZK
+cNF
 bjs
 bkx
 bmQ
@@ -84962,9 +92085,9 @@ bbQ
 bLG
 apd
 aZH
-aZK
+cNF
 bhZ
-aZK
+cNF
 cNM
 bfQ
 bnG
@@ -85804,7 +92927,7 @@ abY
 abY
 aaa
 aaf
-ctv
+cEX
 abY
 abY
 aaa
@@ -85994,7 +93117,7 @@ bqp
 cNG
 cNJ
 bLF
-aZK
+cNF
 bbR
 bbR
 bqt
@@ -86051,18 +93174,18 @@ aaa
 crn
 aaf
 abY
-ctv
-ctv
-ctv
-ctv
-ctv
-ctv
-ctv
+cEX
+cEX
+cEX
+cEX
+cEX
+cEX
+cEX
 abY
 aaa
 aaf
-ctv
-ctv
+cEX
+cEX
 abY
 aaa
 aaa
@@ -86251,7 +93374,7 @@ beW
 bfR
 bKF
 bNH
-aZK
+cNF
 bnJ
 bbR
 bbR
@@ -86503,12 +93626,12 @@ baV
 bON
 apd
 apd
-aZK
+cNF
 beV
 cNI
 bKP
 cNI
-aZK
+cNF
 bnK
 bnK
 bqu
@@ -89129,7 +96252,7 @@ cfG
 cgw
 coK
 cpu
-cqa
+cMm
 ccw
 ccw
 ccw
@@ -89387,7 +96510,7 @@ cjN
 chF
 ciO
 cqc
-cqC
+cTT
 cTV
 ccw
 cEr
@@ -89644,11 +96767,11 @@ cjN
 cjS
 cpv
 cqb
-cqB
-cqU
-cMD
+cTU
+cTW
+cWz
 aaH
-cAk
+cUc
 cUe
 cAp
 cUe
@@ -89659,7 +96782,7 @@ cUe
 cAp
 cUe
 cUe
-cAv
+cUu
 cFb
 ccw
 cUq
@@ -89901,9 +97024,9 @@ cgK
 cjS
 cpv
 cqb
-cqB
+cTU
 cTX
-cMD
+cWz
 aaH
 cAl
 aaH
@@ -90158,9 +97281,9 @@ cgU
 chG
 cpv
 cqd
-cqB
-cqU
-cMD
+cTU
+cTW
+cWz
 cEt
 cAl
 csA
@@ -90416,9 +97539,9 @@ ccw
 cpy
 ccw
 ccw
-cMD
-cMD
-cMD
+cWz
+cWz
+cWz
 cAl
 cEr
 cEr
@@ -90430,7 +97553,7 @@ cEr
 cEr
 cEr
 cHh
-cAw
+cUv
 cFb
 ccw
 cUq
@@ -90675,7 +97798,7 @@ cqf
 chX
 chX
 crs
-cMD
+cWz
 cAl
 cEr
 cEr
@@ -90931,8 +98054,8 @@ cTP
 cqh
 ciZ
 cra
-crI
-cMD
+cTR
+cWz
 cAl
 cEr
 cEr
@@ -91201,7 +98324,7 @@ cFb
 cEr
 cEr
 cHh
-cAw
+cUv
 cEr
 ccw
 cUq
@@ -91438,7 +98561,7 @@ cfb
 cfb
 cig
 cmN
-cnx
+cTL
 cgL
 chX
 cTQ
@@ -91446,7 +98569,7 @@ cqj
 cqH
 crb
 ciZ
-cMD
+cWz
 cAl
 csA
 cFb
@@ -91698,12 +98821,12 @@ cfz
 cgR
 ccw
 ciZ
-crI
+cTR
 cqi
 ciZ
 ciZ
 ciZ
-cMD
+cWz
 cAl
 cEr
 cEr
@@ -91958,9 +99081,9 @@ ccw
 cpy
 ccw
 ccw
-cMD
-cMD
-cMD
+cWz
+cWz
+cWz
 cAl
 cEr
 cEr
@@ -91972,7 +99095,7 @@ cEr
 cEr
 cEr
 cHh
-cAw
+cUv
 cFb
 ccw
 cUq
@@ -92214,9 +99337,9 @@ cgR
 cgR
 cpD
 cDw
-cqB
-cqU
-cMD
+cTU
+cTW
+cWz
 cEt
 cAl
 csA
@@ -92471,9 +99594,9 @@ cgR
 cgR
 cpD
 cqb
-cqB
-cqU
-cMD
+cTU
+cTW
+cWz
 aaH
 cAl
 aaH
@@ -92726,13 +99849,13 @@ cmQ
 cny
 cgR
 cgR
-cnx
+cTL
 cqb
-cqB
-cqU
-cMD
+cTU
+cTW
+cWz
 aaH
-cAn
+cUd
 cUe
 cAr
 cUe
@@ -92743,7 +99866,7 @@ cUe
 cAr
 cUe
 cUe
-cAx
+cUy
 cFb
 ccw
 cUq
@@ -92985,7 +100108,7 @@ cgR
 cgR
 cen
 cqc
-cqC
+cTT
 crc
 ccw
 cEr
@@ -93241,7 +100364,7 @@ ckF
 cDe
 ckF
 cgw
-cqa
+cMm
 ccw
 ccw
 ccw
@@ -98571,11 +105694,11 @@ aJC
 aJC
 aJC
 aJC
-AoF
-HzI
-elp
-UZd
-sKc
+aXj
+aVy
+aSY
+dcC
+dcF
 aYI
 bah
 aJC
@@ -98822,17 +105945,17 @@ aaf
 alP
 aGJ
 aIe
-Prn
+aJE
 aKQ
-eLM
-Tar
+aLU
+aNu
 aJC
-RCR
+aPw
 aKR
 aKR
-fiD
+aSZ
 aKR
-fnE
+dcG
 czP
 bag
 aJC
@@ -99084,12 +106207,12 @@ aJx
 aMi
 aNE
 aOO
-kxC
-kxC
-jrh
-kxC
-MTE
-Bii
+aQi
+aQi
+aSF
+aQi
+dcD
+aXl
 aKR
 bai
 aJC
@@ -99339,14 +106462,14 @@ aHM
 aJm
 aKz
 aKR
-Unp
+aND
 aJC
-ftJ
-NnN
-dxG
+aPP
+aRg
+aQc
 aKR
-uMd
-lfB
+dcE
+aXk
 aKR
 aKR
 aJC
@@ -99601,7 +106724,7 @@ aJC
 aJI
 aJI
 aJI
-pms
+dcB
 aJI
 aJI
 aYK
@@ -101161,7 +108284,7 @@ bkR
 bfL
 boo
 bqQ
-brj
+cWs
 cWt
 bvn
 bwL
@@ -101675,7 +108798,7 @@ bla
 bmY
 bhh
 boq
-brj
+cWs
 cWv
 bsL
 bum
@@ -101932,7 +109055,7 @@ bkU
 bmX
 bpE
 cWr
-brj
+cWs
 cWw
 bti
 bul
@@ -108379,15 +115502,15 @@ bJO
 bWr
 bWr
 dbS
-bTo
-bTo
-bTo
-bTo
+dbN
+dbN
+dbN
+dbN
 bYj
 bZc
 bPN
-bTo
-bTo
+dbN
+dbN
 bQZ
 bNB
 ceM
@@ -108637,13 +115760,13 @@ bQX
 dbO
 bPN
 dbT
-bTo
+dbN
 bWp
-bTo
+dbN
 bYi
 dcg
 dck
-bTo
+dbN
 cbV
 bQZ
 blQ
@@ -108823,7 +115946,7 @@ cTZ
 alP
 cXs
 cXs
-cYa
+dbH
 cYn
 anf
 atB
@@ -108899,9 +116022,9 @@ dca
 bXl
 caZ
 cba
-bSc
+dcl
 cbc
-bTo
+dbN
 bQZ
 cdR
 ceO
@@ -109336,9 +116459,9 @@ aaa
 aaa
 alP
 cXs
-cYa
+dbH
 cXs
-cYa
+dbH
 auC
 alP
 alP
@@ -109409,9 +116532,9 @@ dbM
 bTl
 bQU
 dbW
-bTo
+dbN
 bOw
-bYk
+dce
 dci
 bPN
 cka
@@ -109668,8 +116791,8 @@ bSh
 dbW
 dcb
 bOv
-bYk
-cbY
+dce
+dcj
 bPN
 cjW
 dcs
@@ -109923,9 +117046,9 @@ bSi
 bTm
 bUn
 dbY
-bTo
+dbN
 bOw
-bYk
+dce
 bYm
 bZZ
 ckN
@@ -110366,7 +117489,7 @@ alP
 cXy
 dbI
 cXs
-cYa
+dbH
 anf
 alP
 cYW
@@ -110445,7 +117568,7 @@ cab
 cbd
 cbX
 ccT
-bSc
+dcl
 dcx
 cfu
 cgu
@@ -110947,11 +118070,11 @@ bNy
 bOH
 bEs
 bQY
-bTo
-bTo
-bTo
-bTo
-bTo
+dbN
+dbN
+dbN
+dbN
+dbN
 bXs
 bPL
 bQI
@@ -111203,18 +118326,18 @@ bMy
 bNx
 bOG
 bEs
-bTo
+dbN
 bSk
-bTo
-bTo
-bTo
-bTo
+dbN
+dbN
+dbN
+dbN
 bXr
 bPF
-bTo
-bTo
-bTo
-cbY
+dbN
+dbN
+dbN
+dcj
 bQZ
 cOe
 cNW
@@ -111461,11 +118584,11 @@ bNz
 bOI
 bEs
 bRa
-bTo
-bTo
-bTo
+dbN
+dbN
+dbN
 bVs
-bTo
+dbN
 bXt
 bPM
 bZh


### PR DESCRIPTION
:cl: PopNotes
tweak: Rearranged the bar behind the counter- and to some degree in the backroom- to be less awful and promote robust bartending. Some examples are: Moved around the dispensers and vendor so you can access them all from the same tile, put the shaker in front of you when you spawn and added a chemtank to the working area for storing/vending mixed drinks easily (with a screwdriver in the materials closet).
/:cl:


Preview: ![](http://puu.sh/xJWes/bffb5be499.png)