### PR TITLE
Replaces Reactive Teleport Armor with Reflector Vest

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -709,7 +709,6 @@
 	},
 /obj/item/gun/energy/ionrifle,
 /obj/item/gun/energy/temperature/security,
-/obj/item/clothing/suit/armor/laserproof,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2317,6 +2317,7 @@
 #include "hippiestation\code\game\objects\structures\beds_chairs\chair.dm"
 #include "hippiestation\code\game\objects\structures\crates_lockers\closets\misc.dm"
 #include "hippiestation\code\game\objects\structures\crates_lockers\closets\syndicate.dm"
+#include "hippiestation\code\game\objects\structures\crates_lockers\closets\secure\scientist.dm"
 #include "hippiestation\code\modules\admin\holder2.dm"
 #include "hippiestation\code\modules\admin\secrets.dm"
 #include "hippiestation\code\modules\admin\topic.dm"

--- a/hippiestation/code/game/objects/items/holotool.dm
+++ b/hippiestation/code/game/objects/items/holotool.dm
@@ -101,8 +101,3 @@
 	sharpness = IS_SHARP
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	hitsound = 'sound/weapons/blade1.ogg'
-
-
-/obj/structure/closet/secure_closet/RD/PopulateContents()
-	. = ..()
-	new /obj/item/holotool(src)

--- a/hippiestation/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/hippiestation/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -1,4 +1,4 @@
-s/obj/structure/closet/secure_closet/RD
+/obj/structure/closet/secure_closet/RD
 	name = "\proper research director's locker"
 	req_access = list(ACCESS_RD)
 	icon_state = "rd"

--- a/hippiestation/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/hippiestation/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -19,6 +19,7 @@
 	new /obj/item/tank/internals/air(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/device/megaphone/command(src)
+	new /obj/item/holotool(src)
 	new /obj/item/storage/lockbox/medal/sci(src)
 	new /obj/item/device/assembly/flash/handheld(src)
 	new /obj/item/device/laser_pointer(src)

--- a/hippiestation/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/hippiestation/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -1,0 +1,26 @@
+s/obj/structure/closet/secure_closet/RD
+	name = "\proper research director's locker"
+	req_access = list(ACCESS_RD)
+	icon_state = "rd"
+
+/obj/structure/closet/secure_closet/RD/PopulateContents()
+	new /obj/item/clothing/neck/cloak/rd(src)
+	new /obj/item/clothing/suit/armor/laserproof(src)
+	new /obj/item/clothing/suit/bio_suit/scientist(src)
+	new /obj/item/clothing/head/bio_hood/scientist(src)
+	new /obj/item/clothing/suit/toggle/labcoat(src)
+	new /obj/item/clothing/under/rank/research_director(src)
+	new /obj/item/clothing/under/rank/research_director/alt(src)
+	new /obj/item/clothing/under/rank/research_director/turtleneck(src)
+	new /obj/item/clothing/shoes/sneakers/brown(src)
+	new /obj/item/cartridge/rd(src)
+	new /obj/item/clothing/gloves/color/latex(src)
+	new /obj/item/device/radio/headset/heads/rd(src)
+	new /obj/item/tank/internals/air(src)
+	new /obj/item/clothing/mask/gas(src)
+	new /obj/item/device/megaphone/command(src)
+	new /obj/item/storage/lockbox/medal/sci(src)
+	new /obj/item/device/assembly/flash/handheld(src)
+	new /obj/item/device/laser_pointer(src)
+	new /obj/item/door_remote/research_director(src)
+	new /obj/item/storage/box/firingpins(src)


### PR DESCRIPTION
🆑 PopNotes
balance: The Research Director's locker now has a Reflector Vest instead of Reactive Teleport Armor. The Reflector Vest has subsequently been removed from the armory.
/🆑

[why]: It's been a long time comin' but it finally came