### PR TITLE
Adds some whetstones to the chef's vendor

### DIFF
--- a/hippiestation/code/game/machinery/vending_types.dm
+++ b/hippiestation/code/game/machinery/vending_types.dm
@@ -237,7 +237,7 @@ DINNERWARE
 		/obj/item/kitchen/fork = 6,
 		/obj/item/kitchen/knife = 6,
 		/obj/item/kitchen/rollingpin = 2,
-		/obj/item/sharpener = 2,
+		/obj/item/sharpener = 1,
 		/obj/item/reagent_containers/food/drinks/drinkingglass = 8,
 		/obj/item/clothing/suit/apron/chef = 2,
 		/obj/item/reagent_containers/food/condiment/pack/ketchup = 5,
@@ -249,7 +249,7 @@ DINNERWARE
 	contraband = list(
 		/obj/item/kitchen/rollingpin = 2,
 		/obj/item/kitchen/knife/butcher = 2,
-		/obj/item/sharpener = 1
+		/obj/item/sharpener = 2
 		)
 
 /*

--- a/hippiestation/code/game/machinery/vending_types.dm
+++ b/hippiestation/code/game/machinery/vending_types.dm
@@ -237,6 +237,7 @@ DINNERWARE
 		/obj/item/kitchen/fork = 6,
 		/obj/item/kitchen/knife = 6,
 		/obj/item/kitchen/rollingpin = 2,
+		/obj/item/sharpener = 2,
 		/obj/item/reagent_containers/food/drinks/drinkingglass = 8,
 		/obj/item/clothing/suit/apron/chef = 2,
 		/obj/item/reagent_containers/food/condiment/pack/ketchup = 5,
@@ -247,7 +248,8 @@ DINNERWARE
 		)
 	contraband = list(
 		/obj/item/kitchen/rollingpin = 2,
-		/obj/item/kitchen/knife/butcher = 2
+		/obj/item/kitchen/knife/butcher = 2,
+		/obj/item/sharpener = 1
 		)
 
 /*


### PR DESCRIPTION
:cl: PopNotes
add: A whetstone can now be found in the Plasteel Chef's Dinnerware Vendor. Hack it for more.
/:cl:

Whetstones are fun, they shouldn't be locked behind whether or not someone decides to play chef.