### PR TITLE
Delta on Nuke Op Declaration

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -47,6 +47,7 @@
 		return
 
 	priority_announce(war_declaration, title = "Declaration of War", sound = 'sound/machines/alarm.ogg')
+	set_security_level(SEC_LEVEL_DELTA)
 
 	to_chat(user, "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission.")
 


### PR DESCRIPTION
No more can greytiders go around full stripping the Captain when nuke ops are inbound. Seems fair and appropriate right? Also it's pretty silly that the whole station knows magically when a Syndicate nuke is armed on station. This stops that too.

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
