### PR TITLE
blacklists the blob event from several gamemodes

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2428,6 +2428,7 @@
 #include "hippiestation\code\modules\crafts\vest.dm"
 #include "hippiestation\code\modules\crafts\weaponry.dm"
 #include "hippiestation\code\modules\detectivework\scanner.dm"
+#include "hippiestation\code\modules\events\blob.dm"
 #include "hippiestation\code\modules\events\floorcluwne.dm"
 #include "hippiestation\code\modules\events\immovable_rod.dm"
 #include "hippiestation\code\modules\food_and_drinks\whisk.dm"

--- a/hippiestation/code/modules/events/blob.dm
+++ b/hippiestation/code/modules/events/blob.dm
@@ -1,0 +1,2 @@
+/datum/round_event_control/blob
+	gamemode_blacklist = list("blob","nuclear","revolution","cult","clock_cult","malfunction")


### PR DESCRIPTION
Blob is now blacklisted on: blob (obviously), nuke ops, clock cult, cult, and malfunction. 

:cl: Spacedong
tweak: The random blob event is now blacklisted from several gamemodes: Nuclear Emergency, Cult, Clockwork Cult, Malfunction, and Revolution.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)


These gamemodes have specific, overarching antagonists that the crew must band together to defeat, and having a random giant blob bursting into the station halting the shuttle from escaping and consuming the station interrupts the flow of the gamemodes.