### PR TITLE
Fixes door access in Science

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -41215,7 +41215,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/science{
-	name = "Firing Range"
+	name = "Firing Range";
+	req_access_txt = "47"
 	},
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
@@ -43979,7 +43980,7 @@
 /obj/machinery/firealarm{
 	pixel_x = -24
 	},
-/obj/machinery/chem_heater,
+/obj/structure/closet/wardrobe/science_white,
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
 "bSo" = (
@@ -44415,7 +44416,7 @@
 	pixel_x = -25
 	},
 /obj/effect/decal/cleanable/oil,
-/obj/structure/closet/wardrobe/science_white,
+/obj/machinery/chem_heater,
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
 "bTp" = (
@@ -46050,7 +46051,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/science{
-	name = "High-risk Machinery"
+	name = "High-risk Machinery";
+	req_access_txt = "47"
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
@@ -46597,6 +46599,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 5;
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
@@ -60816,7 +60822,8 @@
 "cDq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/science{
-	name = "Chemical Lab"
+	name = "Chemical Lab";
+	req_access_txt = "47"
 	},
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
@@ -60925,7 +60932,8 @@
 "cDG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/science{
-	name = "Lab Storage"
+	name = "Lab Storage";
+	req_access_txt = "47"
 	},
 /turf/open/floor/plasteel/vault,
 /area/science/misc_lab)
@@ -61001,7 +61009,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/science{
-	name = "High-risk Machinery"
+	name = "High-risk Machinery";
+	req_access_txt = "47"
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)


### PR DESCRIPTION
Doors had no access set so anyone could open them. Now you need Toxins Lab access. I also added a fire extinguisher to the room, and moved the chemical heater one tile down. This is because when certain chemicals were heated, it would always destroy the light it was right next to, an annoyance.

:cl: Esumlogos
bugfix: Science chem doors have their access fixed.
tweak: Chemical heater moved down one tile.
rscadd: Adds a fire extinguisher to Science chem.
/:cl:

Here's a picture.

![](https://i.imgur.com/jxhB1wv.png)
