### PR TITLE
Fixes door to clown office

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -21588,7 +21588,7 @@
 /area/hippie/clown)
 "aXl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/clown{
+/obj/machinery/door/airlock/bananium{
 	name = "Clown's Office";
 	req_access_txt = "46"
 	},

--- a/hippiestation/code/game/machinery/doors/airlock.dm
+++ b/hippiestation/code/game/machinery/doors/airlock.dm
@@ -5,7 +5,7 @@
 	doorDeni = 'hippiestation/sound/machine/denied.ogg'
 	var/request_cooldown = 0 //To prevent spamming requests for the AI to open
 
-/obj/machinery/door/airlock/clown
+/obj/machinery/door/airlock/bananium
 	doorClose = 'sound/items/bikehorn.ogg'
 
 /obj/machinery/door/airlock/AltClick(mob/living/user)


### PR DESCRIPTION
:cl: Pyko
fix: fixed the clown office door to be bananium airlock once again
/:cl:
