### PR TITLE
Clown door fix, take 2

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -65506,7 +65506,7 @@
 /turf/open/floor/plating,
 /area/hippie/clown)
 "cUT" = (
-/obj/machinery/door/airlock/clown{
+/obj/machinery/door/airlock/bananium{
 	name = "Clown's Office";
 	req_access_txt = "46"
 	},


### PR DESCRIPTION
actually fixes it, last time it seems i actually edited un-used mapping shortcut instead of the actual used tile.