### PR TITLE
Adds racial foods preferences

### DIFF
--- a/hippiestation/code/modules/mob/living/carbon/human/species_types/avians.dm
+++ b/hippiestation/code/modules/mob/living/carbon/human/species_types/avians.dm
@@ -10,6 +10,9 @@
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/bird
+	liked_food = FRUIT | VEGETABLES | GRAIN
+	disliked_food = RAW | DAIRY
+	toxic_food = GROSS
 
 /datum/species/bird/on_species_gain(mob/living/carbon/human/C)
 	C.draw_hippie_parts()

--- a/hippiestation/code/modules/mob/living/carbon/human/species_types/ipcs.dm
+++ b/hippiestation/code/modules/mob/living/carbon/human/species_types/ipcs.dm
@@ -9,6 +9,9 @@
 	default_features = list("screen" = "Screen")
 	species_traits = list(MUTCOLORS)
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/ipc
+	liked_food = SUGAR | ALCOHOL
+	disliked_food = DAIRY
+	toxic_food = FRUIT
 
 /datum/species/ipc/on_species_gain(mob/living/carbon/human/C)
 	C.draw_hippie_parts()

--- a/hippiestation/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/hippiestation/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -14,6 +14,8 @@
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard
 	skinned_type = /obj/item/stack/sheet/animalhide/lizard
 	teeth_type = /obj/item/stack/teeth/lizard
+	disliked_food = GRAIN | DAIRY
+	liked_food = GROSS | MEAT
 
 /datum/species/lizard/random_name(gender,unique,lastname)
 	if(unique)

--- a/hippiestation/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/hippiestation/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -10,6 +10,9 @@
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/moth
+	liked_food = VEGETABLES | DAIRY
+	disliked_food = FRUIT | GROSS
+	toxic_food = MEAT | RAW
 
 /datum/species/moth/on_species_gain(mob/living/carbon/C)
 	. = ..()
@@ -36,6 +39,6 @@
 		to_chat(H, "<span class='danger'>Your precious wings burn to a crisp!</span>")
 		H.dna.features["moth_wings"] = "Burnt Off"
 		handle_mutant_bodyparts(H)
-		
+
 /datum/species/moth/check_roundstart_eligible()
 	return TRUE

--- a/hippiestation/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/hippiestation/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -18,3 +18,5 @@
 	damage_overlay_type = ""
 	species_traits = list(LIPS)
 	limbs_id = "skeleton"
+	disliked_food = FRUIT | VEGETABLES
+	liked_food = GROSS | MEAT | RAW

--- a/hippiestation/code/modules/mob/living/carbon/human/species_types/tarajans.dm
+++ b/hippiestation/code/modules/mob/living/carbon/human/species_types/tarajans.dm
@@ -16,6 +16,8 @@
 	burnmod = 1.25
 	brutemod = 1.25
 	teeth_type = /obj/item/stack/teeth/cat
+	liked_food = RAW | MEAT
+	disliked_food = FRUIT | VEGETABLES
 
 /datum/species/tarajan/qualifies_for_rank(rank, list/features)
 	if(rank in GLOB.command_positions) //even if you turn off humans only


### PR DESCRIPTION
:cl: Pyko
add: Added racial food preferences to round start races.
/:cl:

Added racial food preferences to round start races-

Hopefully this would give the chef an incentive to cook different types of foods.
The toxic food is not really toxic, it just makes you net disgust even faster.