### PR TITLE
Changed robotspeak text appearance

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -271,9 +271,6 @@ em						{font-style: normal;	font-weight: bold;}
 
 .say					{}
 .deadsay				{color: #5c00e6;}
-.binarysay    			{color: #20c20e; background-color: #000000; display: block;}
-.binarysay a  			{color: #00ff00;}
-.binarysay a:active, .binarysay a:visited {color: #88ff88;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
 .comradio				{color: #948f02;}

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -10,11 +10,11 @@
 		var/mob/living/silicon/S = src
 		desig = trim_left(S.designation + " " + S.job)
 	var/message_a = say_quote(message, get_spans())
-	var/rendered = "Robotic Talk, <span class='name'>[name]</span> <span class='message'>[message_a]</span>"
+	var/rendered = "<i><span class='game say'>Robotic Talk, <span class='name'>[name]</span> <span class='message'>[message_a]</span></span></i>" // hippie - please don't hurt the eyes
 	for(var/mob/M in GLOB.player_list)
 		if(M.binarycheck())
 			if(isAI(M))
-				var/renderedAI = "<span class='binarysay'>Robotic Talk, <a href='?src=[REF(M)];track=[html_encode(name)]'><span class='name'>[name] ([desig])</span></a> <span class='message'>[message_a]</span></span>"
+				var/renderedAI = "<i><span class='game say'>Robotic Talk, <a href='?src=[REF(M)];track=[html_encode(name)]'><span class='name'>[name] ([desig])</span></a> <span class='message'>[message_a]</span></span></i>" // hippie - please don't hurt the eyes
 				to_chat(M, renderedAI)
 			else
 				to_chat(M, "<span class='binarysay'>[rendered]</span>")

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -36,9 +36,6 @@ em						{font-style: normal;	font-weight: bold;}
 
 .say					{}
 .deadsay				{color: #5c00e6;}
-.binarysay    			{color: #20c20e; background-color: #000000; display: block;}
-.binarysay a  			{color: #00ff00;}
-.binarysay a:active, .binarysay a:visited {color: #88ff88;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
 .comradio				{color: #948f02;}


### PR DESCRIPTION
Changes robotspeak from being horrendously contrasting back to being black text on white text.
Old look: 

![](https://vgy.me/xYrF1z.png)

New look: 

![](https://vgy.me/JPIrCR.png)


:cl: Spacedong
tweak: Silicon binary speech is now black-on-white text like normal, as opposed to green-on-black.
/:cl:


