### PR TITLE
Pixel x = 0 removal

### DIFF
--- a/_maps/map_files/HippieStation/hippiestation.dmm
+++ b/_maps/map_files/HippieStation/hippiestation.dmm
@@ -1623,7 +1623,6 @@
 	desc = "A remote control-switch for privacy shutters.";
 	id = "HOSOffice";
 	name = "Privacy Shutters";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "58"
 	},
@@ -35599,7 +35598,6 @@
 /obj/machinery/button/door{
 	id = "RDOffice";
 	name = "Privacy Shutters";
-	pixel_x = 0;
 	pixel_y = -27;
 	req_access_txt = "47"
 	},


### PR DESCRIPTION
Removes 2 instances of `pixel_x = 0;` that travis keeps notifying about.