### PR TITLE
[FIX] Openwire opens the door when pulsed

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -46,11 +46,12 @@
 		if(WIRE_OPEN) // Pulse to open door (only works not emagged and ID wire is cut or no access is required).
 			if(A.obj_flags & EMAGGED)
 				return
-			if(!A.requiresID() || A.check_access(null))
-				if(A.density)
-					INVOKE_ASYNC(A, /obj/machinery/door/airlock.proc/open)
-				else
-					INVOKE_ASYNC(A, /obj/machinery/door/airlock.proc/close)
+			//hippie start -removes the need to cut ID wire
+			if(A.density)
+				INVOKE_ASYNC(A, /obj/machinery/door/airlock.proc/open)
+			else
+				INVOKE_ASYNC(A, /obj/machinery/door/airlock.proc/close)
+			//hippie end -removes the need to cut ID wire
 		if(WIRE_BOLTS) // Pulse to toggle bolts (but only raise if power is on).
 			if(!A.locked)
 				A.bolt()


### PR DESCRIPTION
Some TG mirror reverted our changes that made the doors open when openwire was pulsed without needing to brick the doors by cutting id wires.

This PR re-adds our changes back to the file.
:cl: Pyko
fix: Pulsing open wire opens the door once again
/:cl: