### PR TITLE
Buff blood-red hardsuit bomb resistance

### DIFF
--- a/hippiestation/code/modules/clothing/suit.dm
+++ b/hippiestation/code/modules/clothing/suit.dm
@@ -41,3 +41,7 @@
 	item_state = "guardarmor"
 	icon = 'hippiestation/icons/obj/clothing/suits.dmi'
 	alternate_worn_icon = 'hippiestation/icons/mob/suit.dmi'
+/obj/item/clothing/suit/space/hardsuit/syndi
+	armor = list("melee" = 40, "bullet" = 50, "laser" = 30, "energy" = 15, "bomb" = 40, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 90)
+/obj/item/clothing/head/helmet/space/hardsuit/syndi
+	armor = list("melee" = 40, "bullet" = 50, "laser" = 30, "energy" = 15, "bomb" = 40, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 90)


### PR DESCRIPTION
:cl: karma
balance: blood-red hardsuits have higher bomb resistance
/:cl:

[why]: Players complaining they're being instakilled by meth bombs

Old: ("melee" = 40, "bullet" = 50, "laser" = 30, "energy" = 15, "bomb" = 35, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 90)
New: ("melee" = 40, "bullet" = 50, "laser" = 30, "energy" = 15, "bomb" = 40, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 90)