### PR TITLE
Revert "you can now black list reagents from strange seeds using can_synth_seeds"

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -367,7 +367,7 @@
 	var/amount_random_reagents = rand(lower, upper)
 	for(var/i in 1 to amount_random_reagents)
 		var/random_amount = rand(4, 15) * 0.01 // this must be multiplied by 0.01, otherwise, it will not properly associate
-		var/datum/plant_gene/reagent/R = new(get_random_reagent_id_seeds(), random_amount) // hippie --  before change line was var/datum/plant_gene/reagent/R = new(get_random_reagent_id(), random_amount); changed this line to use a hippie proc, why: created a new list to improve balance and only blacklist reagents from appearing only in seeds using can_synth_seeds in datum/reagent, this pro was only used by seeds anyway
+		var/datum/plant_gene/reagent/R = new(get_random_reagent_id(), random_amount)
 		if(R.can_add(src))
 			genes += R
 		else

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3180,7 +3180,6 @@
 #include "hippiestation\code\modules\hydroponics\limbflower.dm"
 #include "hippiestation\code\modules\hydroponics\planet_genes.dm"
 #include "hippiestation\code\modules\hydroponics\seed_extractor.dm"
-#include "hippiestation\code\modules\hydroponics\seeds.dm"
 #include "hippiestation\code\modules\hydroponics\grown\berries.dm"
 #include "hippiestation\code\modules\hydroponics\grown\cereals.dm"
 #include "hippiestation\code\modules\hydroponics\grown\flowers.dm"

--- a/hippiestation/code/modules/hydroponics/seeds.dm
+++ b/hippiestation/code/modules/hydroponics/seeds.dm
@@ -1,9 +1,0 @@
-/obj/item/seeds/proc/get_random_reagent_id_seeds()
-	var/static/list/random_reagents = list()
-	if(!random_reagents.len)
-		for(var/thing  in subtypesof(/datum/reagent))
-			var/datum/reagent/R = thing
-			if(initial(R.can_synth) || initial(R.can_synth_seeds))
-				random_reagents += initial(R.id)
-	var/picked_reagent = pick(random_reagents)
-	return picked_reagent

--- a/hippiestation/code/modules/reagents/chemistry/reagents.dm
+++ b/hippiestation/code/modules/reagents/chemistry/reagents.dm
@@ -3,7 +3,6 @@
 	var/boiling_point = 500//the point at which a reagent changes from a liquid to a gaseous state
 	var/melting_point = 273//the point at which a reagent changes from a liquid to a solid state
 	var/processes = FALSE
-	var/can_synth_seeds = TRUE
 
 /datum/reagent/New()
 	..()


### PR DESCRIPTION
Reverts HippieStation/HippieStation#10812
![image](https://user-images.githubusercontent.com/44510065/55975311-9ca36000-5c81-11e9-976f-91abf57312d7.png)
![image](https://user-images.githubusercontent.com/44510065/55975322-a036e700-5c81-11e9-9bd4-91a1104bdbe6.png)
![image](https://user-images.githubusercontent.com/44510065/55975325-a331d780-5c81-11e9-946e-db4e9358002d.png)

