### PR TITLE
Removes chef CQC from the bar

### DIFF
--- a/hippiestation/code/datums/martial/cqc.dm
+++ b/hippiestation/code/datums/martial/cqc.dm
@@ -9,9 +9,7 @@
 	help_verb = /mob/living/carbon/human/proc/CQC_help
 	block_chance = 75
 	var/just_a_cook = FALSE
-	var/static/list/areas_under_siege = typecacheof(list(/area/crew_quarters/kitchen,
-	                                                     /area/crew_quarters/cafeteria,
-														 /area/crew_quarters/bar))
+	var/static/list/areas_under_siege = typecacheof(list(/area/crew_quarters/kitchen))
 
 /datum/martial_art/cqc/under_siege
 	name = "Close Quarters Cooking" // Original name "Culinary School Training"


### PR DESCRIPTION
Chef CQC should be used only to defend themselves in their kitchen and stop people from breaking in, not to use like a retarded chimp on anyone who enters the bar. Maybe give it to the bartender?