### PR TITLE
Remove stand arrow from Lavaland

### DIFF
--- a/hippiestation/code/datums/ruins/lavaland.dm
+++ b/hippiestation/code/datums/ruins/lavaland.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/lavaland/stand_arrow
+/*/datum/map_template/ruin/lavaland/stand_arrow
 	name = "Mysterious Attic"
 	id = "guardian-arrow"
 	suffix = "lavaland_surface_stand.dmm"
@@ -12,4 +12,4 @@
 
 /area/ruin/powered/stand_ruin
 	name = "Mysterious Attic"
-	icon_state = "dk_yellow"
+	icon_state = "dk_yellow"*/


### PR DESCRIPTION
Too many miners keep rolling miner solely to search for it and nothing else and suicide when it's not there, taking up slots and shit. It just causes cancer for no reason when we already have stand-givers on Lavaland which are harder to get