### PR TITLE
[WARNING: SHITCODE]Introducing: The N-word Counter

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -261,6 +261,9 @@
 	parts += medal_report()
 	//Station Goals
 	parts += goal_report()
+	//HIPPIE CHANGES - N word report
+	parts += nword_report()
+	//END CHANGES
 
 	listclearnulls(parts)
 
@@ -420,7 +423,7 @@
 		if(!A.members)
 			continue
 		all_teams |= A
-	
+
 	for(var/datum/antagonist/A in GLOB.antagonists)
 		if(!A.owner)
 			continue
@@ -463,6 +466,13 @@
 
 /proc/cmp_antag_category(datum/antagonist/A,datum/antagonist/B)
 	return sorttext(B.roundend_category,A.roundend_category)
+
+//HIPPIE CHANGES
+/datum/controller/subsystem/ticker/proc/nword_report()
+	for(var/datum/controller/subsystem/ncounter/N in subtypesof(/datum/controller/subsystem))
+		var/list/messages = N.nwordmessages
+		return "<span class='header'>Total N word count: [N.ntimessaid]</span><br><span class='header'>N word messages said:</span><br><div class='panel stationborder'>[messages.Join("<br>")]</div>"
+//END CHANGES
 
 
 /datum/controller/subsystem/ticker/proc/give_show_report_button(client/C)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -5,6 +5,25 @@
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
+	//HIPPIE CHANGES
+	if(findtext("nigger" || "nigga" || "n'wah" || "nations", message)) //N WORD COUNTER!
+		log_admin("[src] (Key: [src.key]) has said the n-word!")
+		for(var/datum/controller/subsystem/ncounter/N in subtypesof(/datum/controller/subsystem))
+			N.nwordmessages += message
+			var/list/nlist = dd_text2list(message," ")
+			var/nword1 = "nigger"
+			var/nword2 = "nigga"
+			var/nword3 = "n'wah"
+			var/nword4 = "nations"
+			for(nword1 in nlist)
+				N.ntimessaid++
+			for(nword2 in nlist)
+				N.ntimessaid++
+			for(nword3 in nlist)
+				N.ntimessaid += 2
+			for(nword4 in nlist)
+				N.ntimessaid += 10
+	//END CHANGES
 	if(message)
 		say(message)
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -6,15 +6,15 @@
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
 	//HIPPIE CHANGES
-	if(findtext("nigger" || "nigga" || "n'wah" || "nations", message)) //N WORD COUNTER!
+	var/nword1 = jointext(list("ni", "g", "g", "er"), "")
+	var/nword2 = jointext(list("ni", "g", "g", "a"), "")
+	var/nword3 = "n'wah"
+	var/nword4 = "nations"
+	if(findtext(nword1 || nword2 || nword3 || nword4, message)) //N WORD COUNTER!
 		log_admin("[src] (Key: [src.key]) has said the n-word!")
 		for(var/datum/controller/subsystem/ncounter/N in subtypesof(/datum/controller/subsystem))
 			N.nwordmessages += message
 			var/list/nlist = dd_text2list(message," ")
-			var/nword1 = "nigger"
-			var/nword2 = "nigga"
-			var/nword3 = "n'wah"
-			var/nword4 = "nations"
 			for(nword1 in nlist)
 				N.ntimessaid++
 			for(nword2 in nlist)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -11,7 +11,7 @@
 	var/nword3 = "n'wah"
 	var/nword4 = "nations"
 	if(findtext(nword1 || nword2 || nword3 || nword4, message)) //N WORD COUNTER!
-		log_admin("[src] (Key: [src.key]) has said the n-word!")
+		/*log_admin("[src] (Key: [src.key]) has said the n-word!")*/ //Commented out so admins are not spammed
 		for(var/datum/controller/subsystem/ncounter/N in subtypesof(/datum/controller/subsystem))
 			N.nwordmessages += message
 			var/list/nlist = dd_text2list(message," ")

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3725,4 +3725,5 @@
 #include "hippiestation\interface\skin.dmf"
 #include "interface\menu.dm"
 #include "interface\stylesheet.dm"
+#include "tools\Redirector\textprocs.dm"
 // END_INCLUDE

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -2944,6 +2944,7 @@
 #include "hippiestation\code\controllers\subsystem\demo.dm"
 #include "hippiestation\code\controllers\subsystem\ipstack.dm"
 #include "hippiestation\code\controllers\subsystem\job.dm"
+#include "hippiestation\code\controllers\subsystem\nwordcounter.dm"
 #include "hippiestation\code\controllers\subsystem\reagent_states.dm"
 #include "hippiestation\code\controllers\subsystem\shuttle.dm"
 #include "hippiestation\code\controllers\subsystem\throwing.dm"

--- a/hippiestation/code/controllers/subsystem/nwordcounter.dm
+++ b/hippiestation/code/controllers/subsystem/nwordcounter.dm
@@ -1,0 +1,5 @@
+SUBSYSTEM_DEF(ncounter)
+	name = "N-word counter"
+	flags = SS_NO_FIRE
+	var/ntimessaid = 0
+	var/list/nwordmessages = list()


### PR DESCRIPTION
## About The Pull Request

(port of https://github.com/Skyrat-SS13/Skyrat13/pull/845 which will definitely be rejected)

Adds an N word counting subsystem, ~~that notifies admins whenever a player says a variation of the N word, and~~ which shows the total count of N words as well as all N word including messages in the round end report.
Future features may include:
Adding n word counts for each individual, and warning (or smiting, even) them if they exceed their n word pass treshold.
Adding the most n-word saying person to the round end report.
Counting Barack Obama (and variations) as 10 n words.
N word passes assigned to each player. Exceeding your assigned use of the n word pass results in smiting.

## Why It's Good For The Game

The gamer word is funny

## Changelog
:cl:
add: N word counter subsystem
tweak: Round end reports now show n word statistics 
/:cl: