### PR TITLE
Spurdo Spadre mask usable as a gas mask

### DIFF
--- a/hippiestation/code/modules/clothing/masks/spurdo.dm
+++ b/hippiestation/code/modules/clothing/masks/spurdo.dm
@@ -3,6 +3,8 @@
 	desc = "Made from a rare Gondola hide. Is said to be cursed by the spirits of Space Finland, which speak through the mask when you scream."
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	flags_1 = MASKINTERNALS
+	flags_cover = MASKCOVERSMOUTH
+	clothing_flags = MASKINTERNALS
 	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "spurdo"
 	item_state = "spurdo"


### PR DESCRIPTION

:cl:
tweak: spurdo mask is now usable as a gas mask
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
destroy the :flag_il:
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
fard
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
