### PR TITLE
Preload http

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -23,7 +23,7 @@
 //#define UNIT_TESTS			//Enables unit tests via TEST_RUN_PARAMETER
 
 #ifndef PRELOAD_RSC				//set to:
-#define PRELOAD_RSC	2			//	0 to allow using external resources or on-demand behaviour;
+#define PRELOAD_RSC	0			//	0 to allow using external resources or on-demand behaviour;
 #endif							//	1 to use the default behaviour;
 								//	2 for preloading absolutely everything;
 


### PR DESCRIPTION
Makes clients dl server files through http instead of byond.
:cl:
config: server resources are now delivered via http instead of byond.
/:cl: